### PR TITLE
[feat] Add issues-10 follow-along entry

### DIFF
--- a/_includes/follow-alongs/follow-along-card.html
+++ b/_includes/follow-alongs/follow-along-card.html
@@ -18,7 +18,13 @@
       </p>
       {% endif %}
       
-      <p class="card-text">{{ include.page.content | markdownify }}</p>
+      <p class="card-text">
+        {% if include.page.summary %}
+          {{ include.page.summary }}
+        {% else %}
+          {{ include.page.content | markdownify }}
+        {% endif %}
+      </p>
 
       {% if page.credits %}
         {% include follow-alongs/{{page.credits}}-credits.html %}

--- a/follow-alongs/my-claude-skills-issues-10.md
+++ b/follow-alongs/my-claude-skills-issues-10.md
@@ -1,0 +1,35 @@
+---
+layout: follow-along
+type: follow-along
+title: "Claude skills: issues-10"
+sequence: 300
+repourl: https://github.com/couimet/my-claude-skills/
+summary: "A real-world walkthrough of how my Claude skills work together to turn messy thoughts into a polished, AI-assisted workflow."
+labels:
+  - ai
+  - claude
+  - skills
+---
+
+<p>
+  This follow-along is my attempt to "show the work" behind
+  <a href="https://github.com/couimet/my-claude-skills#see-it-in-action" target="_blank">how all of my Claude skills fit together</a>
+  in a real issue lifecycle. If you're curious about building your own
+  skill-powered workflows, this is the concrete, end-to-end example that
+  inspired the <code>See It In Action</code> section of the README and is
+  meant to spark ideas for your own setup.
+</p>
+
+<p>
+  This isn't a flashy "watch the UI dance" live demo so much as a
+  back-end dev's brain laid bare — following the actual thought process,
+  complete with detailed traces and a visual timeline of small diffs that
+  show how the plan evolved. The skills were already there; this demo is
+  about capturing the journey and only turning it into a "real" web page
+  at the very end. If that sounds like your kind of fun,
+  you can walk through it at
+  <a href="https://couimet.github.io/my-claude-skills/issues-10/index.html" target="_blank">
+    https://couimet.github.io/my-claude-skills/issues-10/index.html
+  </a>.
+</p>
+


### PR DESCRIPTION
Introduce a new follow-along page that showcases the "issues-10" demo as a concrete, end-to-end example of how existing Claude skills work together, with extra emphasis on the captured traces and visual timeline of iterations, plus a new `summary` field so the follow-along tile stays punchy while the dedicated page keeps all the rich detail.

Benefits:
- Gives readers a story-shaped entry point into the skills instead of just an API list
- Encourages people to reuse the workflow by seeing a real issue lifecycle end to end
- Keeps the follow-alongs grid scannable by separating short summaries from long-form content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new follow-along guide for Claude skills issue tracking with comprehensive documentation and resource links.
  * Follow-along cards now display summaries when available, providing quick content previews.

* **Documentation**
  * New follow-along page includes structured guidance with links to reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->