### PR TITLE
Add portfolio site as project 

### DIFF
--- a/projects/couimet-github-io.md
+++ b/projects/couimet-github-io.md
@@ -1,0 +1,18 @@
+---
+layout: project
+type: project
+title: "This portfolio"
+date: 2000-01-01
+published: true
+repourl: https://github.com/couimet/couimet.github.io
+labels:
+  - portfolio
+  - jekyll
+  - inception
+summary: "My ouimet.info portfolio — a TechFolios-powered site where the content, layout, and even the follow-alongs are all driven from code."
+---
+
+This repo powers my [ouimet.info](https://ouimet.info) portfolio, built by forking the [TechFolios project](https://techfolios.github.io/) and then customizing it through code. I treat it as a project mostly so it has a place to live on the Projects grid, even though the real stars are the tools and experiments it’s pointing to.
+
+One of my favorite corners of the site is the [Career Changelog](https://ouimet.info/#career-changelog), which treats my career like a versioned piece of software, complete with releases, added/changed/deprecated sections, and a long-running changelog.
+


### PR DESCRIPTION
Treat the `couimet.github.io` repo as a first-class project by adding a dedicated project entry that links to ouimet.info, calls out the TechFolios fork and Career Changelog, and labels it as an “inception” portfolio.

Benefits:
- Makes it obvious that the portfolio itself is code-driven and open source
- Creates a clearer on-ramp for visitors who want to inspect or reuse the portfolio setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new portfolio project page showcasing the portfolio itself, including details about its development and a notable Career Changelog feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->