### PR TITLE
[issues/6] Capture smart_todo OS work and YugabyteDB migration in career changelog

### DIFF
--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -24,6 +24,8 @@
       <ul>
         <li>Member of the <a href="https://shop.app/" target="_blank">shop.app</a> team.</li>
         <li id="changelog-400-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank">Ruby</a>; shout-out to <a href="https://pragmaticstudio.com/" target="_blank">The Pragmatic Studio</a>'s <a href="https://pragmaticstudio.com/courses/ruby" target="_blank">Ruby Programming</a> course which helped me quickly learn a language I hadn't used before.<br /> Ruby really reminds me of <a href="https://www.perl.org/" target="_blank">Perl</a>, a language I used extensively when I first started building websites in the late 1990s.</li>
+        <li>First open source contribution to the <a href="https://rubygems.org/gems/smart_todo/versions/1.11.0" target="_blank">smart_todo</a> gem, adding support for a <code>context</code> attribute that can point to a GitHub issue. You can inspect the published diff via <a href="https://my.diffend.io/gems/smart_todo/1.10.0/1.11.0" target="_blank">this 1.10.0 → 1.11.0 comparison</a>.</li>
+        <li>Work on the transition of shop.app ecosystem to <a href="https://www.yugabyte.com/" target="_blank">YugabyteDB</a>, a distributed PostgreSQL-compatible database, as part of Shopify's global commerce infrastructure modernization. Read <a href="https://www.yugabyte.com/success-stories/shopify/" target="_blank">YugabyteDB x Shopify</a> article for more details.</li>
       </ul>
       <h3 id="deprecated">Deprecated</h3>
       <ul>


### PR DESCRIPTION
Document my first public gem contribution to smart_todo and my role in Shopify's ongoing migration to YugabyteDB directly in the Career Changelog, so visitors see concrete, externally-verifiable examples of recent work rather than only internal responsibilities.

Benefits:
- Highlights a specific open source change with public artifacts (RubyGems release and diff) that people can inspect
- Surfaces the YugabyteDB migration and links to the official success story, anchoring the experience in a trusted third-party reference

Closes https://github.com/couimet/couimet.github.io/issues/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog for version 4.0.0 to document an open source contribution with GitHub issue context support.
  * Added documentation of infrastructure ecosystem transition work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->