### PR TITLE
[issues/14] Add rel="noopener noreferrer" to all target="_blank" links

### DIFF
--- a/_includes/about/social.html
+++ b/_includes/about/social.html
@@ -2,7 +2,7 @@
 {% if include.name == 'house' %}
 <a href="{{ url }}">
 {% else %}
-<a href="{{ url }}" target="_blank">
+<a href="{{ url }}" target="_blank" rel="noopener noreferrer">
 {% endif %}
   <svg class="tf-social">
     <use xlink:href="{{ '/img/bootstrap-icons.svg' | prepend: site.baseurl }}#{{- include.name -}}"/>

--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -17,44 +17,44 @@
       </div>
 
       <p>All notable changes to this project (my career) will be documented in this section.</p>
-      <p>The format is based on <a href="https://keepachangelog.com/en/1.1.0/" target="_blank">Keep a Changelog</a> and this project
-        adheres to <a href="https://semver.org/spec/v2.0.0.html" target="_blank">Semantic Versioning</a>.</p>
+      <p>The format is based on <a href="https://keepachangelog.com/en/1.1.0/" target="_blank" rel="noopener noreferrer">Keep a Changelog</a> and this project
+        adheres to <a href="https://semver.org/spec/v2.0.0.html" target="_blank" rel="noopener noreferrer">Semantic Versioning</a>.</p>
       <h2 id="changelog-400">4.0.0 - Staff Software Developer @ Shopify (2025-08 to Present)</h2>
       <h3 id="added">Added</h3>
       <ul>
-        <li>Member of the <a href="https://shop.app/" target="_blank">shop.app</a> team.</li>
-        <li id="changelog-400-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank">Ruby</a>; shout-out to <a href="https://pragmaticstudio.com/" target="_blank">The Pragmatic Studio</a>'s <a href="https://pragmaticstudio.com/courses/ruby" target="_blank">Ruby Programming</a> course which helped me quickly learn a language I hadn't used before.<br /> Ruby really reminds me of <a href="https://www.perl.org/" target="_blank">Perl</a>, a language I used extensively when I first started building websites in the late 1990s.</li>
-        <li>First open source contribution to the <a href="https://rubygems.org/gems/smart_todo/versions/1.11.0" target="_blank">smart_todo</a> gem, adding support for a <code>context</code> attribute that can point to a GitHub issue. You can inspect the published diff via <a href="https://my.diffend.io/gems/smart_todo/1.10.0/1.11.0" target="_blank">this 1.10.0 → 1.11.0 comparison</a>.</li>
-        <li>Work on the transition of shop.app ecosystem to <a href="https://www.yugabyte.com/" target="_blank">YugabyteDB</a>, a distributed PostgreSQL-compatible database, as part of Shopify's global commerce infrastructure modernization. Read <a href="https://www.yugabyte.com/success-stories/shopify/" target="_blank">YugabyteDB x Shopify</a> article for more details.</li>
+        <li>Member of the <a href="https://shop.app/" target="_blank" rel="noopener noreferrer">shop.app</a> team.</li>
+        <li id="changelog-400-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank" rel="noopener noreferrer">Ruby</a>; shout-out to <a href="https://pragmaticstudio.com/" target="_blank" rel="noopener noreferrer">The Pragmatic Studio</a>'s <a href="https://pragmaticstudio.com/courses/ruby" target="_blank" rel="noopener noreferrer">Ruby Programming</a> course which helped me quickly learn a language I hadn't used before.<br /> Ruby really reminds me of <a href="https://www.perl.org/" target="_blank" rel="noopener noreferrer">Perl</a>, a language I used extensively when I first started building websites in the late 1990s.</li>
+        <li>First open source contribution to the <a href="https://rubygems.org/gems/smart_todo/versions/1.11.0" target="_blank" rel="noopener noreferrer">smart_todo</a> gem, adding support for a <code>context</code> attribute that can point to a GitHub issue. You can inspect the published diff via <a href="https://my.diffend.io/gems/smart_todo/1.10.0/1.11.0" target="_blank" rel="noopener noreferrer">this 1.10.0 → 1.11.0 comparison</a>.</li>
+        <li>Work on the transition of shop.app ecosystem to <a href="https://www.yugabyte.com/" target="_blank" rel="noopener noreferrer">YugabyteDB</a>, a distributed PostgreSQL-compatible database, as part of Shopify's global commerce infrastructure modernization. Read <a href="https://www.yugabyte.com/success-stories/shopify/" target="_blank" rel="noopener noreferrer">YugabyteDB x Shopify</a> article for more details.</li>
       </ul>
       <h3 id="deprecated">Deprecated</h3>
       <ul>
-        <li>Octav made a company-wide reorg as part of a strategic pivot and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7356644701598371841/" target="_blank">I had to find my next adventure.</a></li>
+        <li>Octav made a company-wide reorg as part of a strategic pivot and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7356644701598371841/" target="_blank" rel="noopener noreferrer">I had to find my next adventure.</a></li>
       </ul>
       <h2 id="changelog-300">3.0.0 - Principal Software Developer @ Octav (2025-02 to 2025-07)</h2>
       <h3 id="added">Added</h3>
       <ul>
-        <li>Transition to crypto/blockchain world; thanks to <a href="https://www.linkedin.com/in/luc-blackburn-32854788/" target="_blank">Luc Blackburn</a> and <a href="https://www.linkedin.com/in/mbaril010/" target="_blank">Mathieu Baril</a> for providing me the opportunity to enter this world.</li>
-        <li>Many LinkedIn Learning certificates; <a href="https://www.linkedin.com/in/charlesouimet/details/certifications/" target="_blank">check them out</a>!</li>
-        <li>Professional portfolio website: <a href="https://ouimet.info" target="_blank">ouimet.info</a>. I really like my <code>Career Changelog</code> section 🤓.</li>
+        <li>Transition to crypto/blockchain world; thanks to <a href="https://www.linkedin.com/in/luc-blackburn-32854788/" target="_blank" rel="noopener noreferrer">Luc Blackburn</a> and <a href="https://www.linkedin.com/in/mbaril010/" target="_blank" rel="noopener noreferrer">Mathieu Baril</a> for providing me the opportunity to enter this world.</li>
+        <li>Many LinkedIn Learning certificates; <a href="https://www.linkedin.com/in/charlesouimet/details/certifications/" target="_blank" rel="noopener noreferrer">check them out</a>!</li>
+        <li>Professional portfolio website: <a href="https://ouimet.info" target="_blank" rel="noopener noreferrer">ouimet.info</a>. I really like my <code>Career Changelog</code> section 🤓.</li>
         <li>
           Knowledge in the crypto and DeFi space about L2s, block explorers, smart contracts (ABIs), DEXes, MEV (Maximal Extractable Value), flash loans, cross-chain bridges, AMMs, CLMMs, liquidity pools, lending, borrowing, staking, rewards on EVM-compatible chains and Solana. (Rugs and scams included! 🙁)
           <br />
           APIs and libraries: 
-          <a href="https://debank.com/" target="_blank">DeBank</a>, 
-          <a href="https://defillama.com/" target="_blank">DefiLlama</a>, 
-          <a href="https://etherscan.io/" target="_blank">Etherscan</a>, 
-          <a href="https://ethers.org/" target="_blank">ethers</a>, 
-          <a href="https://viem.sh/" target="_blank">viem</a> and many more!
+          <a href="https://debank.com/" target="_blank" rel="noopener noreferrer">DeBank</a>, 
+          <a href="https://defillama.com/" target="_blank" rel="noopener noreferrer">DefiLlama</a>, 
+          <a href="https://etherscan.io/" target="_blank" rel="noopener noreferrer">Etherscan</a>, 
+          <a href="https://ethers.org/" target="_blank" rel="noopener noreferrer">ethers</a>, 
+          <a href="https://viem.sh/" target="_blank" rel="noopener noreferrer">viem</a> and many more!
         </li>
-        <li>Implementation of the <a href="https://defillama.com/protocol/stader" target="_blank">Stader</a> protocol in a forked version of the <a href="https://github.com/sonarwatch/portfolio" target="_blank">SonarWatch Portfolio</a> project.</li>
-        <li>Migration of a GitHub repository that contained a single <code>npm</code> package to a monorepo with multiple packages using <a href="https://turborepo.com/" target="_blank">Turborepo</a> and <a href="https://github.com/changesets/changesets" target="_blank">changeset</a>.</li>
-        <li>Centralized <a href="https://github.com/features/actions" target="_blank">GitHub Actions</a> repository to reduce duplication across CI/CD workflows and improve maintainability.</li>
-        <li>Structured logging across services, enabling efficient log filtering and analysis via <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html" target="_blank">AWS CloudWatch Log Insights</a>.</li>
+        <li>Implementation of the <a href="https://defillama.com/protocol/stader" target="_blank" rel="noopener noreferrer">Stader</a> protocol in a forked version of the <a href="https://github.com/sonarwatch/portfolio" target="_blank" rel="noopener noreferrer">SonarWatch Portfolio</a> project.</li>
+        <li>Migration of a GitHub repository that contained a single <code>npm</code> package to a monorepo with multiple packages using <a href="https://turborepo.com/" target="_blank" rel="noopener noreferrer">Turborepo</a> and <a href="https://github.com/changesets/changesets" target="_blank" rel="noopener noreferrer">changeset</a>.</li>
+        <li>Centralized <a href="https://github.com/features/actions" target="_blank" rel="noopener noreferrer">GitHub Actions</a> repository to reduce duplication across CI/CD workflows and improve maintainability.</li>
+        <li>Structured logging across services, enabling efficient log filtering and analysis via <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html" target="_blank" rel="noopener noreferrer">AWS CloudWatch Log Insights</a>.</li>
       </ul>
       <h3 id="deprecated">Deprecated</h3>
       <ul>
-        <li>Flexport made a reorg in 2024-10 and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7247719867951255552/" target="_blank">it was my turn to look for a new adventure.</a></li>
+        <li>Flexport made a reorg in 2024-10 and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7247719867951255552/" target="_blank" rel="noopener noreferrer">it was my turn to look for a new adventure.</a></li>
       </ul>
       <h2 id="changelog-240">2.4.0 - Senior Staff Developer @ Flexport (2023-06 to 2024-10)</h2>
       <h3 id="added-240">Added</h3>
@@ -71,9 +71,9 @@
       <h3 id="added-230">Added</h3>
       <ul>
         <li>Member of the <code>Technical Leadership Community (TLC)</code>. The mission of our group of 8-10 leaders from across Shopify Logistics' sub-divisions was to guide a team of ~300 developers through the acquisition and standardize best practices. I built presentations and video capsules covering patterns like the transactional outbox, sagas (orchestration vs. choreography), and more.<br />
-          The TLC wasn't about enforcing architecture rules; instead, we served as a sounding board, helping teams validate system designs through collaborative discussions. Shout-out to <a href="https://www.linkedin.com/in/jeremiah-brazeau-17282b3/" target="_blank">Jeremiah Brazeau</a> and <a href="https://www.linkedin.com/in/alireza/" target="_blank">Alireza Assadzadeh</a>.
+          The TLC wasn't about enforcing architecture rules; instead, we served as a sounding board, helping teams validate system designs through collaborative discussions. Shout-out to <a href="https://www.linkedin.com/in/jeremiah-brazeau-17282b3/" target="_blank" rel="noopener noreferrer">Jeremiah Brazeau</a> and <a href="https://www.linkedin.com/in/alireza/" target="_blank" rel="noopener noreferrer">Alireza Assadzadeh</a>.
         </li>
-        <li>Implementation of <code>observability-as-code</code> to streamline the deployment of <a href="https://docs.datadoghq.com/monitors/" target="_blank">DataDog monitors</a> in our <a href="https://en.wikipedia.org/wiki/Continuous_deployment" target="_blank">CD pipelines</a>.</li>
+        <li>Implementation of <code>observability-as-code</code> to streamline the deployment of <a href="https://docs.datadoghq.com/monitors/" target="_blank" rel="noopener noreferrer">DataDog monitors</a> in our <a href="https://en.wikipedia.org/wiki/Continuous_deployment" target="_blank" rel="noopener noreferrer">CD pipelines</a>.</li>
         <li>Knowledge in the logistics industry, working across fulfillment, and supply chain integrations.</li>
       </ul>
       <h3 id="deprecated-230">Deprecated</h3>
@@ -83,9 +83,9 @@
       <h2 id="changelog-220">2.2.0 - Senior Developer @ Deliverr (2021-12 to 2022-07)</h2>
       <h3 id="added-220">Added</h3>
       <ul>
-        <li>Use of <a href="https://tsoa-community.github.io/docs/" target="_blank">TSOA</a>; shout-out to <a href="https://www.linkedin.com/in/galtidhar/" target="_blank">Gal Tidhar</a>.</li>
-        <li>Use of <a href="https://maxwells-daemon.io/" target="_blank">Maxwell</a> as our <a href="https://en.wikipedia.org/wiki/Change_data_capture" target="_blank">change data capture (CDC)</a> solution.</li>
-        <li>Implementation of the <a href="https://microservices.io/patterns/data/transactional-outbox.html" target="_blank">transactional outbox pattern</a> in a brand new service and refactored an already-existing service to use this pattern.</li>
+        <li>Use of <a href="https://tsoa-community.github.io/docs/" target="_blank" rel="noopener noreferrer">TSOA</a>; shout-out to <a href="https://www.linkedin.com/in/galtidhar/" target="_blank" rel="noopener noreferrer">Gal Tidhar</a>.</li>
+        <li>Use of <a href="https://maxwells-daemon.io/" target="_blank" rel="noopener noreferrer">Maxwell</a> as our <a href="https://en.wikipedia.org/wiki/Change_data_capture" target="_blank" rel="noopener noreferrer">change data capture (CDC)</a> solution.</li>
+        <li>Implementation of the <a href="https://microservices.io/patterns/data/transactional-outbox.html" target="_blank" rel="noopener noreferrer">transactional outbox pattern</a> in a brand new service and refactored an already-existing service to use this pattern.</li>
         <li>Definition of the original specification for integration events in our distributed ecosystem, ensuring a robust foundation for inter-service communication.</li>
         <li>Many contributions to our private packages in the organization's NPM repository; improving developers' expericence across our ecosystem.</li>
         <li>A few small Slack communities/sub-groups focusing on domain-driven design, event-driven architecture, serverless technologies, observability, etc.</li>
@@ -94,20 +94,20 @@
       <h2 id="changelog-210">2.1.0 - Tech Lead @ SSENSE (2019-10 to 2021-12)</h2>
       <h3 id="added-210">Added</h3>
       <ul>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Domain-driven_design" target="_blank">Domain-Driven Design (<a href="https://www.linkedin.com/feed/hashtag/?keywords=ddd" target="_blank">#ddd</a>); shout-out to <a href="https://www.linkedin.com/in/mbneto/" target="_blank">Mário Bittencourt</a>.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Event-driven_architecture" target="_blank">Event-Driven Architecture (eda)</a>.</li>
-        <li>Use of <a href="https://refactoring.guru/design-patterns/state/typescript/example" target="_blank">state machine</a> to manage the state of the customer orders in the newly-peeled-off <a href="https://en.wikipedia.org/wiki/Order_management_system" target="_blank">order management system (OMS)</a>.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/SOLID" target="_blank">SOLID principles</a>.</li>
-        <li>Use of <a href="https://medium.com/ssense-tech/hexagonal-architecture-there-are-always-two-sides-to-every-story-bc0780ed7d9c" target="_blank">hexagonal architecture</a>; shout-out to <a href="https://www.linkedin.com/in/pablomtz/" target="_blank">Pablo Martinez</a>.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Event_storming" target="_blank">event storming</a>.</li>
-        <li>Use of <a href="https://c4model.com/" target="_blank">C4 model</a>.</li>
-        <li>Use of <a href="https://www.serverless.com/" target="_blank">serverless framework</a> and other serverless-focused AWS technologies (like <a href="https://aws.amazon.com/pm/lambda/" target="_blank">Lambda</a>).</li>
-        <li>Use of <a href="https://aws.amazon.com/pm/dynamodb" target="_blank">DynamoDB</a>.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/OpenAPI_Specification" target="_blank">OpenAPI Specification</a> to officialize our contracts; shout-out to <a href="https://www.linkedin.com/in/mbneto/" target="_blank">Mário Bittencourt</a> for <a href="https://medium.com/ssense-tech/shifting-perspectives-placing-api-design-at-the-core-of-development-6fd9fe5b69a3" target="_blank">his article</a>.</li>
-        <li>Use of <a href="https://www.bpmn.org/" target="_blank">BPMN (Business Process Model and Notation)</a>.</li>
-        <li>Project to peel-off the <a href="https://en.wikipedia.org/wiki/Order_management_system" target="_blank">order management system (OMS)</a> out of the company's <a href="https://en.wikipedia.org/wiki/Monolithic_application" target="_blank">monolith</a> to its own DDD domain/microservices.</li>
-        <li>Use of <code>TypeScript</code> and <code>Node.js</code>; shout-out to <a href="https://www.linkedin.com/in/yannickcordinier/" target="_blank">Yannick Cordinier</a>.</li>
-        <li>Use of <a href="https://github.com/features/copilot" target="_blank">GitHub Copilot</a> as my favourite coding buddy.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Domain-driven_design" target="_blank" rel="noopener noreferrer">Domain-Driven Design (<a href="https://www.linkedin.com/feed/hashtag/?keywords=ddd" target="_blank" rel="noopener noreferrer">#ddd</a>); shout-out to <a href="https://www.linkedin.com/in/mbneto/" target="_blank" rel="noopener noreferrer">Mário Bittencourt</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Event-driven_architecture" target="_blank" rel="noopener noreferrer">Event-Driven Architecture (eda)</a>.</li>
+        <li>Use of <a href="https://refactoring.guru/design-patterns/state/typescript/example" target="_blank" rel="noopener noreferrer">state machine</a> to manage the state of the customer orders in the newly-peeled-off <a href="https://en.wikipedia.org/wiki/Order_management_system" target="_blank" rel="noopener noreferrer">order management system (OMS)</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/SOLID" target="_blank" rel="noopener noreferrer">SOLID principles</a>.</li>
+        <li>Use of <a href="https://medium.com/ssense-tech/hexagonal-architecture-there-are-always-two-sides-to-every-story-bc0780ed7d9c" target="_blank" rel="noopener noreferrer">hexagonal architecture</a>; shout-out to <a href="https://www.linkedin.com/in/pablomtz/" target="_blank" rel="noopener noreferrer">Pablo Martinez</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Event_storming" target="_blank" rel="noopener noreferrer">event storming</a>.</li>
+        <li>Use of <a href="https://c4model.com/" target="_blank" rel="noopener noreferrer">C4 model</a>.</li>
+        <li>Use of <a href="https://www.serverless.com/" target="_blank" rel="noopener noreferrer">serverless framework</a> and other serverless-focused AWS technologies (like <a href="https://aws.amazon.com/pm/lambda/" target="_blank" rel="noopener noreferrer">Lambda</a>).</li>
+        <li>Use of <a href="https://aws.amazon.com/pm/dynamodb" target="_blank" rel="noopener noreferrer">DynamoDB</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/OpenAPI_Specification" target="_blank" rel="noopener noreferrer">OpenAPI Specification</a> to officialize our contracts; shout-out to <a href="https://www.linkedin.com/in/mbneto/" target="_blank" rel="noopener noreferrer">Mário Bittencourt</a> for <a href="https://medium.com/ssense-tech/shifting-perspectives-placing-api-design-at-the-core-of-development-6fd9fe5b69a3" target="_blank" rel="noopener noreferrer">his article</a>.</li>
+        <li>Use of <a href="https://www.bpmn.org/" target="_blank" rel="noopener noreferrer">BPMN (Business Process Model and Notation)</a>.</li>
+        <li>Project to peel-off the <a href="https://en.wikipedia.org/wiki/Order_management_system" target="_blank" rel="noopener noreferrer">order management system (OMS)</a> out of the company's <a href="https://en.wikipedia.org/wiki/Monolithic_application" target="_blank" rel="noopener noreferrer">monolith</a> to its own DDD domain/microservices.</li>
+        <li>Use of <code>TypeScript</code> and <code>Node.js</code>; shout-out to <a href="https://www.linkedin.com/in/yannickcordinier/" target="_blank" rel="noopener noreferrer">Yannick Cordinier</a>.</li>
+        <li>Use of <a href="https://github.com/features/copilot" target="_blank" rel="noopener noreferrer">GitHub Copilot</a> as my favourite coding buddy.</li>
         <li>Member of <code>Technical Architecture Group (TAG)</code>. With the architects, Staff & Principal Engineers, our group of 6-10 people established the departments' tech standards. Oversaw the projects of 3 other teams to ensure they followed the established standards while still applying best practices to reach the targeted software <i>*ilities</i>.</li>
         <li>Winner of Hackathon 2019 with my idea to improve the onboarding process of new hires.</li>
         <li>Knowledge in the luxury e-commerce industry and distributed order management systems.</li>
@@ -119,29 +119,29 @@
       <h2 id="changelog-200">2.0.0 - Senior Developer @ Zola (2019-01 to 2019-10)</h2>
       <h3 id="added-200">Added</h3>
       <ul>
-        <li>Use of <a href="https://aws.amazon.com/" target="_blank">Amazon Web Services (AWS)</a>.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank">microservices</a>.</li>
-        <li>Use of <a href="https://www.atlassian.com/continuous-delivery/continuous-integration/trunk-based-development" target="_blank">trunk-based development</a>.</li>
-        <li>Use of <a href="https://www.split.io/feature-flags-best-practices-ebook/" target="_blank">feature flags</a>.</li>
-        <li><a href="https://aws.amazon.com/certification/certified-cloud-practitioner/" target="_blank">AWS Certified Cloud Practitioner</a> certification <a href="https://www.credly.com/badges/c3ccd5a7-dc9e-433d-95c5-5a8278a00b60/" target="_blank">issued on 2019-04-19</a>.</li>
+        <li>Use of <a href="https://aws.amazon.com/" target="_blank" rel="noopener noreferrer">Amazon Web Services (AWS)</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="noopener noreferrer">microservices</a>.</li>
+        <li>Use of <a href="https://www.atlassian.com/continuous-delivery/continuous-integration/trunk-based-development" target="_blank" rel="noopener noreferrer">trunk-based development</a>.</li>
+        <li>Use of <a href="https://www.split.io/feature-flags-best-practices-ebook/" target="_blank" rel="noopener noreferrer">feature flags</a>.</li>
+        <li><a href="https://aws.amazon.com/certification/certified-cloud-practitioner/" target="_blank" rel="noopener noreferrer">AWS Certified Cloud Practitioner</a> certification <a href="https://www.credly.com/badges/c3ccd5a7-dc9e-433d-95c5-5a8278a00b60/" target="_blank" rel="noopener noreferrer">issued on 2019-04-19</a>.</li>
         <li>Knowledge in the wedding and event planning industry.</li>
         <li>Knowledge in the e-commerce industry.</li>
       </ul>
       <h3 id="changed-200">Changed</h3>
       <ul>
-        <li>The type of companies I worked for; shout-out to <a href="https://www.linkedin.com/in/yavery/" target="_blank">Yan Avery</a> for providing me the opportunity to enter <i>startup world</i>.</li>
+        <li>The type of companies I worked for; shout-out to <a href="https://www.linkedin.com/in/yavery/" target="_blank" rel="noopener noreferrer">Yan Avery</a> for providing me the opportunity to enter <i>startup world</i>.</li>
       </ul>
       <h2 id="changelog-120">1.2.0 - Architect @ AFS Technologies (2011-11 to 2018-12)</h2>
       <h3 id="added-120">Added</h3>
       <ul>
-        <li>Skills to develop <a href="https://en.wikipedia.org/wiki/Software_as_a_service" target="_blank">SaaS solutions</a>.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Agile_software_development" target="_blank">Agile methodologies</a>.</li>
+        <li>Skills to develop <a href="https://en.wikipedia.org/wiki/Software_as_a_service" target="_blank" rel="noopener noreferrer">SaaS solutions</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Agile_software_development" target="_blank" rel="noopener noreferrer">Agile methodologies</a>.</li>
         <li>Use of <code>Java</code>, <code>Spring framework</code>, <code>Hibernate</code>, <code>Mockito</code>.</li>
-        <li>Building of <a href="https://en.wikipedia.org/wiki/REST" target="_blank">REST</a> APIs.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Continuous_integration" target="_blank">Continuous Integration (CI)</a> pipelines.</li>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Extract,_transform,_load" target="_blank">ETL (Extract, Transform, Load)</a> processes and <a href="https://en.wikipedia.org/wiki/MultiDimensional_eXpressions" target="_blank">MDX query language</a> in a <a href="https://en.wikipedia.org/wiki/Microsoft_Analysis_Services" target="_blank">Microsoft SQL Server Analysis Services (SSAS)</a> environment.</li>        
-        <li><a href="https://en.wikipedia.org/wiki/Scrum_(software_development)" target="_blank">Scrum Master</a> certification.</li>
-        <li>Knowledge in the <a href="https://en.wikipedia.org/wiki/Fast-moving_consumer_goods" target="_blank">consumer packaged goods (CPG)</a> industry.</li>
+        <li>Building of <a href="https://en.wikipedia.org/wiki/REST" target="_blank" rel="noopener noreferrer">REST</a> APIs.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Continuous_integration" target="_blank" rel="noopener noreferrer">Continuous Integration (CI)</a> pipelines.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Extract,_transform,_load" target="_blank" rel="noopener noreferrer">ETL (Extract, Transform, Load)</a> processes and <a href="https://en.wikipedia.org/wiki/MultiDimensional_eXpressions" target="_blank" rel="noopener noreferrer">MDX query language</a> in a <a href="https://en.wikipedia.org/wiki/Microsoft_Analysis_Services" target="_blank" rel="noopener noreferrer">Microsoft SQL Server Analysis Services (SSAS)</a> environment.</li>        
+        <li><a href="https://en.wikipedia.org/wiki/Scrum_(software_development)" target="_blank" rel="noopener noreferrer">Scrum Master</a> certification.</li>
+        <li>Knowledge in the <a href="https://en.wikipedia.org/wiki/Fast-moving_consumer_goods" target="_blank" rel="noopener noreferrer">consumer packaged goods (CPG)</a> industry.</li>
       </ul>
       <h3 id="changed-120">Changed</h3>
       <ul>
@@ -150,7 +150,7 @@
       <h2 id="changelog-110">1.1.0 - Senior Developer @ Vidéotron (2006-07 to 2011-10)</h2>
       <h3 id="added-110">Added</h3>
       <ul>
-        <li>Knowledge in the telecommunications sector (specializing on the <a href="https://www.techtarget.com/searchnetworking/definition/network-management-system" target="_blank">network management system</a>).</li>
+        <li>Knowledge in the telecommunications sector (specializing on the <a href="https://www.techtarget.com/searchnetworking/definition/network-management-system" target="_blank" rel="noopener noreferrer">network management system</a>).</li>
       </ul>
       <h2 id="changelog-100">1.0.0 - Senior Developer @ Markzware Software (2001-03 to 2006-06)</h2>
       <h3 id="added-100">Added</h3>

--- a/_includes/follow-alongs/dapp-university-credits.html
+++ b/_includes/follow-alongs/dapp-university-credits.html
@@ -1,15 +1,15 @@
 <p>Credit for the repo I forked: 
-  <a href="https://www.linkedin.com/in/gregory-mccubbin-48735b37/" target="_blank">
+  <a href="https://www.linkedin.com/in/gregory-mccubbin-48735b37/" target="_blank" rel="noopener noreferrer">
     <svg class="tf-social">
       <use xlink:href="/img/bootstrap-icons.svg#linkedin"/>
     </svg>
   </a>
-  <a href="https://www.youtube.com/@DappUniversity" target="_blank">
+  <a href="https://www.youtube.com/@DappUniversity" target="_blank" rel="noopener noreferrer">
     <svg class="tf-social">
       <use xlink:href="/img/bootstrap-icons.svg#youtube"/>
     </svg>
   </a>
-  <a href="https://www.instagram.com/dappuniversity/" target="_blank">
+  <a href="https://www.instagram.com/dappuniversity/" target="_blank" rel="noopener noreferrer">
     <svg class="tf-social">
       <use xlink:href="/img/bootstrap-icons.svg#instagram"/>
     </svg>

--- a/_includes/follow-alongs/follow-along-card.html
+++ b/_includes/follow-alongs/follow-along-card.html
@@ -10,7 +10,7 @@
       
       {% if page.instagram %}
       <p>
-        <a href="{{page.instagram}}" target="_blank">
+        <a href="{{page.instagram}}" target="_blank" rel="noopener noreferrer">
           <svg class="tf-social">
             <use xlink:href="/img/bootstrap-icons.svg#instagram"/>
           </svg> post
@@ -33,7 +33,7 @@
     <div class="card-footer">
       <div class="text-center">
         {% if page.repourl %}
-          <a href="{{ page.repourl }}" class="btn btn-outline-dark" target="_blank">My repo</a>
+          <a href="{{ page.repourl }}" class="btn btn-outline-dark" target="_blank" rel="noopener noreferrer">My repo</a>
         {% else %}
           <a href="{{ site.baseurl}}{{ include.page.url }}" class="btn btn-outline-dark">Read More</a>
         {% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="container-fluid">
     <div class="ms-auto">
       <ul class="navbar-nav mb-2 mb-lg-0">
-        <small><a class="nav-link" href="https://techfolios.github.io" target="_blank">Made with Techfolios</a></small>
+        <small><a class="nav-link" href="https://techfolios.github.io" target="_blank" rel="noopener noreferrer">Made with Techfolios</a></small>
       </ul>
     </div>
   </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         <a class="nav-link" href="{{ '/#projects' | prepend: site.baseurl }}">Projects</a>
         <a class="nav-link" href="{{ '/#follow-alongs' | prepend: site.baseurl }}">Follow-alongs</a>
         <a class="nav-link" style="padding-right: 4px;"  href="{{ '/resume.html' | prepend: site.baseurl }}" title="Resume: view page">Resume</a>
-        <a class="nav-link" style="padding-left: 0px;" href="{{ site.data.bio.basics.resumeUrlPdf }}" target="_blank" title="Resume: download PDF"><svg class="tf-social">
+        <a class="nav-link" style="padding-left: 0px;" href="{{ site.data.bio.basics.resumeUrlPdf }}" target="_blank" rel="noopener noreferrer" title="Resume: download PDF"><svg class="tf-social">
           <use xlink:href="{{ '/img/bootstrap-icons.svg' | prepend: site.baseurl }}#filetype-pdf"/>
         </svg>
         </a>

--- a/_layouts/follow-along.html
+++ b/_layouts/follow-along.html
@@ -10,13 +10,13 @@ layout: home
   {% endfor %}
   </p>
 
-  <p><a href="{{ page.repourl }}" target="_blank">Visit my repo</a></p>
+  <p><a href="{{ page.repourl }}" target="_blank" rel="noopener noreferrer">Visit my repo</a></p>
 
   {{ content }}
 
   {% if page.instagram %}
   <p>
-    <a href="{{page.instagram}}" target="_blank">
+    <a href="{{page.instagram}}" target="_blank" rel="noopener noreferrer">
       <svg class="tf-social">
         <use xlink:href="/img/bootstrap-icons.svg#instagram"/>
       </svg> post

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -30,7 +30,7 @@ layout: home
       {% endfor %}
     </p>
 
-    <p class="mb-0"><a href="{{ page.repourl }}" target="_blank">Visit my repo</a></p>
+    <p class="mb-0"><a href="{{ page.repourl }}" target="_blank" rel="noopener noreferrer">Visit my repo</a></p>
   </div>
 
   <div class="mt-3">

--- a/follow-alongs/fun-pump.md
+++ b/follow-alongs/fun-pump.md
@@ -12,4 +12,4 @@ labels:
   - dapp
 ---
 
-<p>This repository was forked from <a href="https://github.com/dappuniversity/fun-pump" target="_blank">dappuniversity/fun-pump</a>.</p>
+<p>This repository was forked from <a href="https://github.com/dappuniversity/fun-pump" target="_blank" rel="noopener noreferrer">dappuniversity/fun-pump</a>.</p>

--- a/follow-alongs/millow.md
+++ b/follow-alongs/millow.md
@@ -12,4 +12,4 @@ labels:
   - dapp
 ---
 
-<p>This repository was forked from <a href="https://github.com/dappuniversity/millow" target="_blank">dappuniversity/millow</a>.</p>
+<p>This repository was forked from <a href="https://github.com/dappuniversity/millow" target="_blank" rel="noopener noreferrer">dappuniversity/millow</a>.</p>

--- a/follow-alongs/my-claude-skills-issues-10.md
+++ b/follow-alongs/my-claude-skills-issues-10.md
@@ -13,7 +13,7 @@ labels:
 ---
 
 <p>
-  If you came here from my <a href="https://dev.to/couimet/from-vide-coding-to-supercharged-vibe-guiding-6nm" target="_blank">From Vide Coding to Supercharged Vibe Guiding</a> post, this is the part where we stop talking about the idea—and actually execute it.
+  If you came here from my <a href="https://dev.to/couimet/from-vide-coding-to-supercharged-vibe-guiding-6nm" target="_blank" rel="noopener noreferrer">From Vide Coding to Supercharged Vibe Guiding</a> post, this is the part where we stop talking about the idea—and actually execute it.
 </p>
 
 <p>
@@ -25,5 +25,5 @@ labels:
 </p>
 
 <p>
-  You can walk through the full timeline here: <a href="https://couimet.github.io/my-claude-skills/issues-10/index.html" target="_blank">View the full issue → PR timeline</a>.
+  You can walk through the full timeline here: <a href="https://couimet.github.io/my-claude-skills/issues-10/index.html" target="_blank" rel="noopener noreferrer">View the full issue → PR timeline</a>.
 </p>

--- a/projects/my-claude-skills.md
+++ b/projects/my-claude-skills.md
@@ -18,5 +18,5 @@ Each skill focuses on one part of the developer workflow (planning, execution, q
 
 If you want to see these skills in action, start with:
 
-- The <a href="https://github.com/couimet/my-claude-skills#see-it-in-action" target="_blank"><code>See It In Action</code> section of the README</a>, which walks through the full issue lifecycle these skills are built around
+- The <a href="https://github.com/couimet/my-claude-skills#see-it-in-action" target="_blank" rel="noopener noreferrer"><code>See It In Action</code> section of the README</a>, which walks through the full issue lifecycle these skills are built around
 - The <a href="{{ site.baseurl }}/follow-alongs/my-claude-skills-issues-10.html">From Blank Issue to PR — With the Thinking Exposed</a> follow-along on this site, which mirrors that demo in a more narrative, portfolio-friendly format

--- a/resume.html
+++ b/resume.html
@@ -79,7 +79,7 @@ layout: home
       </div>
       <div class="col-lg-9">
         <p class="m-0">
-         <a href="{{ site.data.bio.basics.resumeUrlPdf }}" target="_blank">Download <svg class="tf-social">
+         <a href="{{ site.data.bio.basics.resumeUrlPdf }}" target="_blank" rel="noopener noreferrer">Download <svg class="tf-social">
           <use xlink:href="{{ '/img/bootstrap-icons.svg' | prepend: site.baseurl }}#filetype-pdf"/>
         </svg></a>
         </p>


### PR DESCRIPTION
## Summary

This change mitigates reverse-tabnabbing by adding `rel="noopener noreferrer"` to every anchor that opens in a new tab (`target="_blank"`), including links with a `title` attribute on the resume nav control. Coverage matches the sitewide audit from the issue: layouts, shared includes, follow-along pages, the career changelog, `resume.html`, and project markdown. `_includes/about/social.html` was also updated—the issue footnote claimed it already had `rel`, but it did not; adding it keeps external social links consistent with the rest of the site.

## Changes

- Pair `target="_blank"` with `rel="noopener noreferrer"` across all previously audited locations (see commit `fc35dba`).
- Handle the header resume link pattern `target="_blank" title="..."` so `rel` sits with the other attributes without changing behavior.
- Apply the same pattern to social profile links in `_includes/about/social.html` for completeness.

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated external link attributes across website pages and content files for improved link handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->