### PR TITLE
Improve missing page (404) to use full vertical space like the other pages now do

### DIFF
--- a/_layouts/missingpage.html
+++ b/_layouts/missingpage.html
@@ -3,12 +3,14 @@ layout: default
 ---
 
 {% include header.html %}
-
-<div class="py-3 py-md-4 py-lg-5">
-  <div class="container">
-    <h1 class="display-4">Page Not Found</h1>
-    <p>Please visit my <a href="{{ '/resume.html' | prepend: site.baseurl }}">Resume</a> page for more info.</p>
+<main class="flex-grow-1 d-flex flex-column">
+  <div class="py-3 py-md-4 py-lg-5">
+    <div class="container">
+      <h1 class="display-4">Page Not Found</h1>
+      <p>Please visit my <a href="{{ '/resume.html' | prepend: site.baseurl }}">Resume</a> page for more info.</p>
+    </div>
   </div>
-</div>
+  <div class="flex-grow-1"></div>
+</main>
 
 {% include footer.html %}


### PR DESCRIPTION
A small tweak has also been applied to have the content near the top rather than centered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout structure of the Page Not Found (404) page to improve spacing and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->