### PR TITLE
[issues/20] Add pulse highlight and share button for article anchors

### DIFF
--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -32,7 +32,7 @@
         {% endif %}
         {% capture article_href %}{{ link_base }}{{ utm_separator }}utm_source=ouimet.info&utm_medium=referral&utm_campaign={{ utm_campaign | url_encode }}{{ link_fragment }}{% endcapture %}
         <article class="article-item px-3 py-2" id="article-{{ article.anchor }}">
-          <p class="article-date mb-1">{{ article.date }}</p>
+          <p class="article-date mb-1">{{ article.date }}<button class="article-share" aria-label="Copy link to this article" title="Copy link to this article" data-anchor="article-{{ article.anchor }}">🔗</button></p>
           <a
             class="article-link"
             href="{{ article_href }}"
@@ -61,10 +61,42 @@
       var el = document.getElementById(id);
       if (!el) return;
 
-      el.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+      el.classList.remove("pulse");
+      void el.offsetWidth;
+      el.classList.add("pulse");
+      setTimeout(function () { el.classList.remove("pulse"); }, 6000);
+
+      el.scrollIntoView({ behavior: "smooth", block: "nearest" });
     }
 
-    window.addEventListener("DOMContentLoaded", revealAnchoredArticle);
+    function handleShareClick(e) {
+      var btn = e.target.closest(".article-share");
+      if (!btn) return;
+      e.stopPropagation();
+      var anchor = btn.getAttribute("data-anchor");
+      if (!anchor) return;
+      var url = window.location.origin + window.location.pathname + "#" + anchor;
+      navigator.clipboard.writeText(url).then(function () {
+        showShareToast(btn, "Copied");
+      }).catch(function () {
+        showShareToast(btn, "Copy failed");
+      });
+    }
+
+    function showShareToast(btn, text) {
+      var existing = btn.parentElement.querySelector(".article-share-toast");
+      if (existing) existing.remove();
+      var toast = document.createElement("span");
+      toast.className = "article-share-toast";
+      toast.textContent = text;
+      btn.insertAdjacentElement("afterend", toast);
+      setTimeout(function () { toast.remove(); }, 1500);
+    }
+
+    window.addEventListener("DOMContentLoaded", function () {
+      revealAnchoredArticle();
+      document.addEventListener("click", handleShareClick);
+    });
     window.addEventListener("hashchange", revealAnchoredArticle);
   })();
 </script>

--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -61,12 +61,12 @@
       var el = document.getElementById(id);
       if (!el) return;
 
+      var prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       el.classList.remove("pulse");
       void el.offsetWidth;
       el.classList.add("pulse");
-      setTimeout(function () { el.classList.remove("pulse"); }, 6000);
+      setTimeout(function () { el.classList.remove("pulse"); }, prefersReduced ? 2000 : 6000);
 
-      var prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       el.scrollIntoView({ behavior: prefersReduced ? "auto" : "smooth", block: "nearest" });
     }
 

--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -32,7 +32,7 @@
         {% endif %}
         {% capture article_href %}{{ link_base }}{{ utm_separator }}utm_source=ouimet.info&utm_medium=referral&utm_campaign={{ utm_campaign | url_encode }}{{ link_fragment }}{% endcapture %}
         <article class="article-item px-3 py-2" id="article-{{ article.anchor }}">
-          <p class="article-date mb-1">{{ article.date }}<button class="article-share" aria-label="Copy link to this article" title="Copy link to this article" data-anchor="article-{{ article.anchor }}">🔗</button></p>
+          <p class="article-date mb-1">{{ article.date }}<button type="button" class="article-share" aria-label="Copy link to this article" title="Copy link to this article" data-anchor="article-{{ article.anchor }}">🔗</button></p>
           <a
             class="article-link"
             href="{{ article_href }}"
@@ -66,7 +66,8 @@
       el.classList.add("pulse");
       setTimeout(function () { el.classList.remove("pulse"); }, 6000);
 
-      el.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      var prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      el.scrollIntoView({ behavior: prefersReduced ? "auto" : "smooth", block: "nearest" });
     }
 
     function handleShareClick(e) {
@@ -76,6 +77,10 @@
       var anchor = btn.getAttribute("data-anchor");
       if (!anchor) return;
       var url = window.location.origin + window.location.pathname + "#" + anchor;
+      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+        showShareToast(btn, "Copy failed");
+        return;
+      }
       navigator.clipboard.writeText(url).then(function () {
         showShareToast(btn, "Copied");
       }).catch(function () {
@@ -88,6 +93,9 @@
       if (existing) existing.remove();
       var toast = document.createElement("span");
       toast.className = "article-share-toast";
+      toast.setAttribute("role", "status");
+      toast.setAttribute("aria-live", "polite");
+      toast.setAttribute("aria-atomic", "true");
       toast.textContent = text;
       btn.insertAdjacentElement("afterend", toast);
       setTimeout(function () { toast.remove(); }, 1500);

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -124,6 +124,15 @@ a {
   opacity: 1;
 }
 
+@media (hover: none) {
+  .article-share {
+    opacity: 0.7;
+  }
+  .article-share:active {
+    opacity: 1;
+  }
+}
+
 .article-share-toast {
   display: inline-block;
   margin-left: 2px;

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -16,6 +16,8 @@
   --tf-articles-row-even-bg-color: rgba(0, 0, 0, 0.02);
   --tf-articles-row-hover-bg-color: rgba(0, 0, 0, 0.06);
   --tf-articles-pulse-bg-color: rgba(13, 110, 253, 0.12);
+  --tf-articles-toast-bg-color: #0d6efd;
+  --tf-articles-toast-fg-color: #ffffff;
 }
 
 /* Format social media icons */
@@ -125,8 +127,8 @@ a {
 .article-share-toast {
   display: inline-block;
   margin-left: 2px;
-  background: #0d6efd;
-  color: #ffffff;
+  background: var(--tf-articles-toast-bg-color);
+  color: var(--tf-articles-toast-fg-color);
   border: none;
   border-radius: 4px;
   padding: 1px 8px;
@@ -163,5 +165,15 @@ a {
 @media (max-width: 767.98px) {
   .articles-scroll {
     max-height: 260px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .article-item.pulse {
+    animation: none;
+    background: var(--tf-articles-pulse-bg-color);
+  }
+  .article-share-toast {
+    animation: none;
   }
 }

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -15,6 +15,7 @@
   --tf-articles-border-color: rgba(0, 0, 0, 0.08);
   --tf-articles-row-even-bg-color: rgba(0, 0, 0, 0.02);
   --tf-articles-row-hover-bg-color: rgba(0, 0, 0, 0.06);
+  --tf-articles-pulse-bg-color: rgba(13, 110, 253, 0.12);
 }
 
 /* Format social media icons */
@@ -91,6 +92,64 @@ a {
 .article-date {
   color: var(--bs-gray-600);
   font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.article-share {
+  -webkit-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  line-height: 1;
+  padding: 1px 4px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+  border-radius: 3px;
+}
+
+.article-item:hover .article-share,
+.article-share:focus {
+  opacity: 0.7;
+}
+
+.article-share:hover {
+  opacity: 1;
+}
+
+.article-share-toast {
+  display: inline-block;
+  margin-left: 2px;
+  background: #0d6efd;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  padding: 1px 8px;
+  font-size: 0.7rem;
+  pointer-events: none;
+  animation: article-share-toast-fade 1.5s ease forwards;
+  vertical-align: middle;
+}
+
+@keyframes article-share-toast-fade {
+  0%   { opacity: 0; transform: translateX(4px); }
+  15%  { opacity: 1; transform: translateX(0); }
+  80%  { opacity: 1; transform: translateX(0); }
+  100% { opacity: 0; transform: translateX(-2px); }
+}
+
+@keyframes article-pulse {
+  0%, 100% { background: transparent; }
+  50%      { background: var(--tf-articles-pulse-bg-color); }
+}
+
+.article-item.pulse {
+  animation: article-pulse 2s ease-in-out 3;
 }
 
 .article-link {


### PR DESCRIPTION
## Summary

When a visitor arrives via a URL like `/#article-dry-ing-double-paying`, the targeted article row now pulses with a three-cycle breathing highlight so their eye lands on the right place. A hover-revealed 🔗 share button was also added next to each article's date, letting anyone copy a site-local deep link to that row — sharing back to ouimet.info rather than directly to the external article.

## Changes

- `css/techfolio-theme/default.css`: added `--tf-articles-pulse-bg-color` CSS variable, `@keyframes article-pulse` (3 × 2 s breathing effect in Bootstrap blue at low opacity), `.article-item.pulse` rule, `.article-share` button styles (hidden by default, revealed on row hover), `.article-share-toast` with `@keyframes article-share-toast-fade` (solid blue badge, white text, slides in and fades out over 1.5 s), and `inline-flex` layout on `.article-date` to seat the button inline with the date text
- `_includes/articles/articles.html`: added `<button class="article-share" data-anchor="article-{{ article.anchor }}">🔗</button>` inside each article's date paragraph; updated inline `<script>` — `revealAnchoredArticle` now applies the pulse pattern (remove class → force reflow → add class → `scrollIntoView nearest` → clear after 6 s) and `handleShareClick` copies `window.location.origin + pathname + '#article-' + anchor` to clipboard with a "Copied" toast on success

## Technical notes

Removing the class before re-adding it forces a reflow (`void el.offsetWidth`) so the animation restarts cleanly even on repeated navigations via `hashchange`. The share URL is built from `window.location` so it resolves correctly whether the visitor is on `/` or `/articles/` without any hardcoding. `block: "nearest"` is used for `scrollIntoView` so the browser only scrolls if the element is actually outside the viewport.

## Test Plan

- [ ] `http://localhost:4000/#article-dry-ing-double-paying` — smooth scroll to article + 3-cycle pulse fires
- [ ] `http://localhost:4000/articles/#article-dry-ing-double-paying` — same on the full articles page
- [ ] Navigate between two article anchors in the same tab — `hashchange` path triggers pulse each time
- [ ] Hover any article row → 🔗 appears → click it → "Copied" toast appears and fades; clipboard contains the correct site-local URL
- [ ] Click the article title link — navigates externally, share button does not intercept

## Related

Closes https://github.com/couimet/couimet.github.io/issues/20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a share button next to article dates that copies the article's canonical URL to the clipboard.
  * Visual toast notifications confirm success or show errors and gracefully fade.
  * Articles receive a brief pulsing highlight when navigated to; share controls fade in on hover and focus.
  * Anchored articles are revealed on load and support delegated click handling for sharing.

* **Accessibility**
  * Respects reduced-motion preferences by disabling animations and using instant scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->