### PR TITLE
[issues/21] Add scroll-based URL hash tracking for sections and articles

### DIFF
--- a/_includes/about/about.html
+++ b/_includes/about/about.html
@@ -1,4 +1,4 @@
-<div style="background-color: var(--tf-page-bg-color)" class="bg-gradient py-3">
+<div style="background-color: var(--tf-page-bg-color)" class="bg-gradient py-3" id="about">
   <div class="container">
     <div class="row">
       <div class="col-lg-4">

--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -101,9 +101,41 @@
       setTimeout(function () { toast.remove(); }, 1500);
     }
 
+    var articleUserScrolled = false;
+    window.addEventListener("scroll", function () { articleUserScrolled = true; }, { once: true, passive: true });
+
+    function initArticleScrollSpy() {
+      var container = document.querySelector(".articles-scroll-full");
+      if (!container) return;
+
+      var items = container.querySelectorAll(".article-item[id]");
+      if (!items.length || !("IntersectionObserver" in window)) return;
+
+      var currentArticleHash = "";
+      var spy = new IntersectionObserver(function (entries) {
+        var best = null;
+        entries.forEach(function (entry) {
+          if (entry.isIntersecting) {
+            if (!best || entry.intersectionRatio > best.intersectionRatio) {
+              best = entry;
+            }
+          }
+        });
+        if (best && best.target.id && best.target.id !== currentArticleHash) {
+          currentArticleHash = best.target.id;
+          if (articleUserScrolled) {
+            history.replaceState(null, "", "#" + best.target.id);
+          }
+        }
+      }, { threshold: [0.3, 0.5, 0.7], rootMargin: "-10% 0px -60% 0px" });
+
+      items.forEach(function (item) { spy.observe(item); });
+    }
+
     window.addEventListener("DOMContentLoaded", function () {
       revealAnchoredArticle();
       document.addEventListener("click", handleShareClick);
+      initArticleScrollSpy();
     });
     window.addEventListener("hashchange", revealAnchoredArticle);
   })();

--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -102,7 +102,10 @@
     }
 
     var articleUserScrolled = false;
-    window.addEventListener("scroll", function () { articleUserScrolled = true; }, { once: true, passive: true });
+    function markUserScrolled() { articleUserScrolled = true; }
+    ["pointerdown", "wheel", "keydown", "touchstart"].forEach(function (type) {
+      window.addEventListener(type, markUserScrolled, { once: true, passive: true });
+    });
 
     function initArticleScrollSpy() {
       var container = document.querySelector(".articles-scroll-full");
@@ -116,7 +119,8 @@
         var best = null;
         entries.forEach(function (entry) {
           if (entry.isIntersecting) {
-            if (!best || entry.intersectionRatio > best.intersectionRatio) {
+            var top = entry.boundingClientRect.top;
+            if (top >= 0 && (!best || top < best.boundingClientRect.top)) {
               best = entry;
             }
           }

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,3 +6,68 @@ layout: default
   {{ content }}
 </main>
 {% include footer.html %}
+{% if page.url == '/' %}
+<script>
+  (function () {
+    var sectionIds = ["about", "projects", "articles", "follow-alongs", "career-changelog"];
+    var sections = sectionIds.map(function (id) { return document.getElementById(id); }).filter(Boolean);
+    if (!sections.length) return;
+
+    var userHasScrolled = false;
+    var currentSectionHash = "";
+    var ticking = false;
+
+    function getActiveSection() {
+      // Active = last section whose top is above 20% of the viewport.
+      // Works for both short and tall sections; deterministic, no ties.
+      var triggerY = window.scrollY + window.innerHeight * 0.2;
+      var active = null;
+      for (var i = 0; i < sections.length; i++) {
+        if (sections[i].offsetTop <= triggerY) active = sections[i];
+      }
+      return active;
+    }
+
+    function updateHash() {
+      ticking = false;
+      if (!userHasScrolled) return;
+
+      var active = getActiveSection();
+
+      if (!active) {
+        if (window.location.hash) {
+          currentSectionHash = "";
+          history.replaceState(null, "", window.location.pathname);
+        }
+        return;
+      }
+
+      var id = active.id;
+      // Don't clobber an article-level hash when re-entering the articles section
+      if (id === "articles" && window.location.hash.startsWith("#article-")) return;
+
+      // "about" is the implicit top — keep the URL clean with no hash
+      if (id === "about") {
+        if (window.location.hash) {
+          currentSectionHash = "";
+          history.replaceState(null, "", window.location.pathname);
+        }
+        return;
+      }
+
+      if (id !== currentSectionHash) {
+        currentSectionHash = id;
+        history.replaceState(null, "", "#" + id);
+      }
+    }
+
+    window.addEventListener("scroll", function () {
+      if (!userHasScrolled) userHasScrolled = true;
+      if (!ticking) {
+        requestAnimationFrame(updateHash);
+        ticking = true;
+      }
+    }, { passive: true });
+  })();
+</script>
+{% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -11,6 +11,7 @@ layout: default
   (function () {
     var sectionIds = ["about", "projects", "articles", "follow-alongs", "career-changelog"];
     var sections = sectionIds.map(function (id) { return document.getElementById(id); }).filter(Boolean);
+    sections.sort(function (a, b) { return a.offsetTop - b.offsetTop; });
     if (!sections.length) return;
 
     var userHasScrolled = false;


### PR DESCRIPTION
## Summary

As a visitor scrolls through the landing page, the browser URL now silently updates to reflect the current section (`#projects`, `#articles`, `#follow-alongs`, `#career-changelog`). The about section at the top is the implicit default — the URL stays clean with no hash while it is active. On the `/articles/` page, the hash tracks the specific article row currently in view (`#article-dry-ing-double-paying`, etc.) — making every position on the site directly shareable. Both use `history.replaceState` so there is no scroll jump, no history pollution, and no interference with the existing anchor-scroll and pulse behaviour from issue #20.

## Changes

- `_includes/about/about.html`: added `id="about"` to the outer section div — needed so the scroll spy can detect when the user is back at the top
- `_layouts/home.html`: added an inline `<script>` (landing page only, guarded by `page.url == '/'`) using a passive scroll listener + `requestAnimationFrame` to throttle updates; `getActiveSection()` finds the last section whose `offsetTop` is above 20 % of the viewport — deterministic and works for sections of any height including the tall career-changelog; `#about` is treated as the clean-URL state (hash cleared rather than set); includes a `userHasScrolled` guard to prevent stamping a hash into history on initial page load; also guards against overwriting an `#article-*` hash when re-entering the articles section
- `_includes/articles/articles.html`: added `initArticleScrollSpy` inside the existing IIFE — activates only when `.articles-scroll-full` is present (i.e., the full `/articles/` page, not the capped landing-page list), observes each `.article-item` with `IntersectionObserver` and the same `userHasScrolled` guard, updates hash to `#article-{anchor}` as the user scrolls

## Test Plan

**Landing page — section tracking**
- [ ] Open http://127.0.0.1:4000/ and scroll slowly down — URL bar should step through `#projects` → `#articles` → `#follow-alongs` → `#career-changelog`
- [ ] Scroll all the way to the bottom — `#career-changelog` must appear (was broken with the IntersectionObserver approach due to section height)
- [ ] Scroll back to the top — hash should clear and URL should return to `http://127.0.0.1:4000/` with no fragment
- [ ] Fresh load of http://127.0.0.1:4000/ — URL should NOT update without scrolling (`userHasScrolled` guard)

**Articles page — article tracking**
- [ ] Open http://127.0.0.1:4000/articles/ and scroll down — URL bar should step through each `#article-*` anchor in order
- [ ] Direct load of http://127.0.0.1:4000/articles/#article-vibe-guiding — pulse fires on the correct row; URL should NOT be overwritten until the user scrolls

**Regression — existing pulse and share behaviour**
- [ ] http://127.0.0.1:4000/#article-dry-ing-double-paying — pulse fires on the correct row, share button still copies the right URL
- [ ] On the landing page, scroll to the articles section (`#articles` in URL), then click 🔗 on an article — URL should update to the article-level anchor and NOT revert to `#articles` on the next scroll callback

## Related

Closes https://github.com/couimet/couimet.github.io/issues/21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic URL updates that reflect your current scroll position on the homepage for shareable links to sections.
  * Scroll-spy for article lists that updates the URL to the active article after user interaction, without disrupting manual article hashes.
  * Added an anchorable ID to the About section for direct linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->