### PR TITLE
[issues/23] Move sync script backup to dedicated folder as compressed archive

### DIFF
--- a/.github/workflows/deploy-ouimet-info.yml
+++ b/.github/workflows/deploy-ouimet-info.yml
@@ -78,9 +78,17 @@ jobs:
           password: ${{ inputs.password }}           # Option C: key: ${{ secrets.OUIMET_INFO_SSH_PRIVATE_KEY }}  ← field name changes from 'password' to 'key'
           fingerprint: ${{ inputs.fingerprint }}     # Option C: ${{ secrets.OUIMET_INFO_SSH_FINGERPRINT }}
           script: |
-            BACKUP="${{ inputs.remote_path }}-backup-$(date +%Y%m%d-%H%M%S)"
-            cp -r "${{ inputs.remote_path }}" "$BACKUP"
-            echo "Backup created at $BACKUP"
+            BACKUP_DIR="$HOME/ouimet_info_backups"
+            BACKUP_FILE="$BACKUP_DIR/$(date +%Y%m%d-%H%M%S).tar.gz"
+            BACKUP_PARENT="$(dirname "${{ inputs.remote_path }}")"
+            BACKUP_NAME="$(basename "${{ inputs.remote_path }}")"
+            mkdir -p "$BACKUP_DIR"
+            if [[ -d "${{ inputs.remote_path }}" ]]; then
+              tar -czf "$BACKUP_FILE" -C "$BACKUP_PARENT" "$BACKUP_NAME"
+              echo "Backup created at $BACKUP_FILE"
+            else
+              echo "No existing site; skipping backup (first run)"
+            fi
 
       # scp uploads only files present in _site/. It does not delete anything
       # on the server, other files and folders are left untouched.

--- a/scripts/sync-ouimet-info.sh
+++ b/scripts/sync-ouimet-info.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run this script ON your server after SSH-ing in.
 # It mirrors the live couimet.github.io site to your ouimet.info web root,
-# creating a timestamped backup first so you can roll back if needed.
+# creating a compressed backup first so you can roll back if needed.
 #
 # To download this script directly on the server:
 #   wget -O sync-ouimet-info.sh https://raw.githubusercontent.com/couimet/couimet.github.io/main/scripts/sync-ouimet-info.sh && chmod +x sync-ouimet-info.sh
@@ -11,12 +11,15 @@
 set -euo pipefail
 
 REMOTE_PATH="$HOME/ouimet_info"
-BACKUP_PATH="${REMOTE_PATH}-backup-$(date +%Y%m%d-%H%M%S)"
+BACKUP_DIR="$HOME/ouimet_info_backups"
+BACKUP_FILE="$BACKUP_DIR/$(date +%Y%m%d-%H%M%S).tar.gz"
 
-echo "==> Backing up current site to $BACKUP_PATH"
-cp -r "$REMOTE_PATH" "$BACKUP_PATH"
+mkdir -p "$BACKUP_DIR"
+
+echo "==> Backing up current site to $BACKUP_FILE"
+tar -czf "$BACKUP_FILE" -C "$HOME" ouimet_info
 echo "    Backup created. To roll back:"
-echo "    rm -rf $REMOTE_PATH && mv $BACKUP_PATH $REMOTE_PATH"
+echo "    rm -rf $REMOTE_PATH && mkdir $REMOTE_PATH && tar -xzf $BACKUP_FILE -C $HOME"
 echo ""
 
 echo "==> Mirroring couimet.github.io into $REMOTE_PATH"
@@ -32,4 +35,4 @@ wget \
 
 echo ""
 echo "==> Done. ouimet.info web root is now up to date."
-echo "    Backup kept at: $BACKUP_PATH"
+echo "    Backup kept at: $BACKUP_FILE"

--- a/scripts/sync-ouimet-info.sh
+++ b/scripts/sync-ouimet-info.sh
@@ -16,10 +16,17 @@ BACKUP_FILE="$BACKUP_DIR/$(date +%Y%m%d-%H%M%S).tar.gz"
 
 mkdir -p "$BACKUP_DIR"
 
-echo "==> Backing up current site to $BACKUP_FILE"
-tar -czf "$BACKUP_FILE" -C "$HOME" ouimet_info
-echo "    Backup created. To roll back:"
-echo "    rm -rf $REMOTE_PATH && mkdir $REMOTE_PATH && tar -xzf $BACKUP_FILE -C $HOME"
+BACKUP_PARENT="$(dirname "$REMOTE_PATH")"
+BACKUP_NAME="$(basename "$REMOTE_PATH")"
+
+if [[ -d "$REMOTE_PATH" ]]; then
+  echo "==> Backing up current site to $BACKUP_FILE"
+  tar -czf "$BACKUP_FILE" -C "$BACKUP_PARENT" "$BACKUP_NAME"
+  echo "    Backup created. To roll back:"
+  echo "    rm -rf \"$REMOTE_PATH\" && tar -xzf \"$BACKUP_FILE\" -C \"$BACKUP_PARENT\""
+else
+  echo "==> No existing site at $REMOTE_PATH; skipping backup (first run)"
+fi
 echo ""
 
 echo "==> Mirroring couimet.github.io into $REMOTE_PATH"


### PR DESCRIPTION
## Summary

Improves the backup strategy in `scripts/sync-ouimet-info.sh`: backups are now tar.gz archives stored in a dedicated `~/ouimet_info_backups/` directory instead of uncompressed directory copies placed next to the web root. This keeps backups organized, reduces disk usage, and avoids sibling-directory clutter in the home directory.

## Changes

- `scripts/sync-ouimet-info.sh` — replaced `cp -r` backup with `tar -czf` into `~/ouimet_info_backups/YYYYMMDD-HHMMSS.tar.gz`; the backups directory is created automatically on first run; rollback instructions updated to use `tar -xzf`
- Documentation: CHANGELOG not needed — internal tooling script; README not needed

## Test Plan

- [ ] SSH into ouimet.info server, run the updated script, verify `~/ouimet_info_backups/` is created and contains a `.tar.gz` file
- [ ] Verify the web root sync still completes successfully after the backup step
- [ ] Optionally test rollback: `rm -rf ~/ouimet_info && mkdir ~/ouimet_info && tar -xzf ~/ouimet_info_backups/<file>.tar.gz -C ~`

## Related

Closes https://github.com/couimet/couimet.github.io/issues/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded backup procedures to utilize compressed archives, enhancing storage efficiency and reducing the time required for backup and restore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->