### PR TITLE
[issues/23] Replace wget mirror with GitHub Release zip download for ouimet.info sync

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-# contents: write is required to publish the site.zip GitHub Release used by sync-ouimet-info.sh
+# Workflow-level permissions (least privilege — contents: write is scoped to the build job only)
 permissions:
-  contents: write
+  contents: read
   pages: write
   id-token: write
 
@@ -31,6 +30,10 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required to publish the site.zip GitHub Release used by sync-ouimet-info.sh
+      pages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,7 +57,8 @@ jobs:
       - name: Publish site.zip as GitHub Release
         # Overwrites the 'latest' release on every push so the download URL stays stable:
         # https://github.com/couimet/couimet.github.io/releases/latest/download/site.zip
-        uses: softprops/action-gh-release@v2
+        # Pinned to commit SHA for supply-chain safety (v2 = 3bb12739...)
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: latest
           name: Latest site build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,9 @@ on:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# contents: write is required to publish the site.zip GitHub Release used by sync-ouimet-info.sh
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -47,6 +48,19 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+      - name: Package _site as zip for ouimet.info sync
+        # zip from inside _site so paths are root-relative (not _site/foo) when extracted
+        run: cd _site && zip -r ../site.zip .
+      - name: Publish site.zip as GitHub Release
+        # Overwrites the 'latest' release on every push so the download URL stays stable:
+        # https://github.com/couimet/couimet.github.io/releases/latest/download/site.zip
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          name: Latest site build
+          body: "Auto-published on every push to main. Used by scripts/sync-ouimet-info.sh to sync ouimet.info."
+          files: site.zip
+          make_latest: true
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@v3

--- a/scripts/sync-ouimet-info.sh
+++ b/scripts/sync-ouimet-info.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 # Run this script ON your server after SSH-ing in.
-# It mirrors the live couimet.github.io site to your ouimet.info web root,
-# creating a compressed backup first so you can roll back if needed.
+# It downloads the latest site.zip from the GitHub Release for this repo and
+# extracts it into the ouimet.info web root, creating a compressed backup first.
+# Files not in the zip (charles/, sarah/, .htaccess) are left untouched.
 #
 # To download this script directly on the server:
 #   wget -O sync-ouimet-info.sh https://raw.githubusercontent.com/couimet/couimet.github.io/main/scripts/sync-ouimet-info.sh && chmod +x sync-ouimet-info.sh
-#
-# Safe for existing server-only directories: wget only downloads files from the
-# source and never deletes anything. Other files and folders are left untouched.
 set -euo pipefail
 
 REMOTE_PATH="$HOME/ouimet_info"
 BACKUP_DIR="$HOME/ouimet_info_backups"
 BACKUP_FILE="$BACKUP_DIR/$(date +%Y%m%d-%H%M%S).tar.gz"
+ZIP_TMP="/tmp/ouimet_info_site.zip"
+RELEASE_URL="https://github.com/couimet/couimet.github.io/releases/latest/download/site.zip"
 
 mkdir -p "$BACKUP_DIR"
 
@@ -26,19 +26,16 @@ if [[ -d "$REMOTE_PATH" ]]; then
   echo "    rm -rf \"$REMOTE_PATH\" && tar -xzf \"$BACKUP_FILE\" -C \"$BACKUP_PARENT\""
 else
   echo "==> No existing site at $REMOTE_PATH; skipping backup (first run)"
+  mkdir -p "$REMOTE_PATH"
 fi
 echo ""
 
-echo "==> Mirroring couimet.github.io into $REMOTE_PATH"
-wget \
-  --mirror \
-  --page-requisites \
-  --no-parent \
-  --no-host-directories \
-  --directory-prefix="$REMOTE_PATH" \
-  --quiet \
-  --show-progress \
-  https://couimet.github.io/
+echo "==> Downloading latest site build"
+wget -q --show-progress -O "$ZIP_TMP" "$RELEASE_URL"
+
+echo "==> Extracting into $REMOTE_PATH"
+unzip -o "$ZIP_TMP" -d "$REMOTE_PATH"
+rm "$ZIP_TMP"
 
 echo ""
 echo "==> Done. ouimet.info web root is now up to date."

--- a/scripts/sync-ouimet-info.sh
+++ b/scripts/sync-ouimet-info.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Run this script ON your server after SSH-ing in.
 # It downloads the latest site.zip from the GitHub Release for this repo and
-# extracts it into the ouimet.info web root, creating a compressed backup first.
-# Files not in the zip (charles/, sarah/, .htaccess) are left untouched.
+# syncs it into the ouimet.info web root, creating a compressed backup first.
+# Requires: wget, unzip, rsync (all confirmed available on the server).
+# Files explicitly excluded from sync (charles/, sarah/, .htaccess) are preserved.
+# Files removed from the Jekyll build are removed from the server (rsync --delete).
 #
 # To download this script directly on the server:
 #   wget -O sync-ouimet-info.sh https://raw.githubusercontent.com/couimet/couimet.github.io/main/scripts/sync-ouimet-info.sh && chmod +x sync-ouimet-info.sh
@@ -12,7 +14,10 @@ REMOTE_PATH="$HOME/ouimet_info"
 BACKUP_DIR="$HOME/ouimet_info_backups"
 BACKUP_FILE="$BACKUP_DIR/$(date +%Y%m%d-%H%M%S).tar.gz"
 ZIP_TMP="/tmp/ouimet_info_site.zip"
+STAGING_DIR="$(mktemp -d)"
 RELEASE_URL="https://github.com/couimet/couimet.github.io/releases/latest/download/site.zip"
+
+trap 'rm -f "$ZIP_TMP"; rm -rf "$STAGING_DIR"' EXIT
 
 mkdir -p "$BACKUP_DIR"
 
@@ -33,9 +38,15 @@ echo ""
 echo "==> Downloading latest site build"
 wget -q --show-progress -O "$ZIP_TMP" "$RELEASE_URL"
 
-echo "==> Extracting into $REMOTE_PATH"
-unzip -o "$ZIP_TMP" -d "$REMOTE_PATH"
-rm "$ZIP_TMP"
+echo "==> Extracting into staging directory"
+unzip -q "$ZIP_TMP" -d "$STAGING_DIR"
+
+echo "==> Syncing into $REMOTE_PATH (files removed from the build will be deleted)"
+rsync -a --delete \
+  --exclude 'charles/' \
+  --exclude 'sarah/' \
+  --exclude '.htaccess' \
+  "$STAGING_DIR"/ "$REMOTE_PATH"/
 
 echo ""
 echo "==> Done. ouimet.info web root is now up to date."


### PR DESCRIPTION
## Summary

The `wget --mirror` approach used in `scripts/sync-ouimet-info.sh` is fundamentally limited: it crawls links and silently skips any file not reachable by following hyperlinks. Jekyll's `404.html` is never linked from any page, so it was never downloaded, meaning ouimet.info could not serve a local 404 page and still depended on a redirect to `couimet.github.io/404-page`. This change replaces the crawl with a zip-based release artifact that captures the complete Jekyll build output unconditionally.

## Changes

- `scripts/sync-ouimet-info.sh` — replaces the `wget --mirror` block with a download of `site.zip` from the GitHub Release (`releases/latest/download/site.zip`) followed by `unzip -o` into the web root; server-only files (charles/, sarah/, .htaccess) are untouched since unzip only adds/overwrites, never deletes; also adds `mkdir -p "$REMOTE_PATH"` for first-run safety
- `.github/workflows/main.yml` — adds two steps after the Jekyll build: (1) `cd _site && zip -r ../site.zip .` to package the full build output with root-relative paths, (2) `softprops/action-gh-release@v2` to publish `site.zip` as a GitHub Release tagged `latest`, overwriting it on every push; `contents` permission updated from `read` to `write` to allow release creation
- `ouimet.info/.htaccess` line 25 — changed `ErrorDocument 404 https://couimet.github.io/404-page` to `ErrorDocument 404 /404.html`; eliminates the last hard dependency on couimet.github.io
- Documentation: CHANGELOG not needed — infrastructure tooling; README not needed

## Key Discoveries

- `wget --mirror` is the wrong tool for static site sync: it follows links, not the filesystem, so unlinked files like `404.html`, and any future unlinked assets, are silently dropped
- GitHub Release assets on a public repo are permanently downloadable without authentication via a stable URL (`releases/latest/download/site.zip`), making them the right choice over artifacts (which expire after 90 days and require a token)
- The zip must be created with `cd _site && zip -r ../site.zip .` (not `zip -r site.zip _site/`) so paths inside the archive are root-relative; wrong packaging would extract into a nested `_site/` subdirectory on the server

## Test Plan

- [ ] Push to main and verify the GitHub Actions workflow creates/updates the `latest` release with a `site.zip` asset
- [ ] SSH into ouimet.info server, run `scripts/sync-ouimet-info.sh`, verify `404.html` is present in `~/ouimet_info/` after extraction
- [ ] Browse to a non-existent URL on ouimet.info and confirm the local 404 page is served (not a redirect to couimet.github.io)
- [ ] Confirm charles/ and sarah/ directories are untouched after sync

## Related

Closes https://github.com/couimet/couimet.github.io/issues/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure updates to site distribution. Built site content is now packaged and automatically published to GitHub Releases with a stable, permanent download URL. This enables reliable external synchronization of site content and provides offline access to the complete site package for backup and deployment purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->