### PR TITLE
[issues/28] Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy-ouimet-info.yml
+++ b/.github/workflows/deploy-ouimet-info.yml
@@ -71,7 +71,7 @@ jobs:
           JEKYLL_ENV: production
 
       - name: Backup existing site on server
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@v1.2.5
         with:
           host: ${{ inputs.host }}                  # Option C: ${{ secrets.OUIMET_INFO_SSH_HOST }}
           username: ${{ inputs.username }}           # Option C: ${{ secrets.OUIMET_INFO_SSH_USERNAME }}
@@ -93,7 +93,7 @@ jobs:
       # scp uploads only files present in _site/. It does not delete anything
       # on the server, other files and folders are left untouched.
       - name: Upload built site
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v1.0.0
         with:
           host: ${{ inputs.host }}                  # Option C: ${{ secrets.OUIMET_INFO_SSH_HOST }}
           username: ${{ inputs.username }}           # Option C: ${{ secrets.OUIMET_INFO_SSH_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -67,7 +67,7 @@ jobs:
           make_latest: true
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
 
   # Deployment job
   deploy:
@@ -79,4 +79,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

GitHub Actions will force Node.js 24 as the default runtime on June 2, 2026 and remove Node.js 20 on September 16, 2026. The `actions/deploy-pages@v4` action was explicitly flagged in a workflow run warning. This bumps all GitHub-managed Pages actions to their latest Node.js 24-compatible versions and takes the opportunity to update the appleboy SSH/SCP actions in the manual deploy workflow to their latest releases.

## Changes

**`main.yml` — Node.js 24 compatibility:**
- `actions/configure-pages@v4` → `@v5`
- `actions/upload-pages-artifact@v3` → `@v4`
- `actions/deploy-pages@v4` → `@v5` — eliminates the deprecation warning that triggered this issue

**`deploy-ouimet-info.yml` — routine version bumps (composite/Docker actions, not Node.js affected):**
- `appleboy/ssh-action@v1.2.0` → `@v1.2.5`
- `appleboy/scp-action@v0.1.7` → `@v1.0.0` (Docker → composite runtime in v1)

Documentation: CHANGELOG not needed — CI infrastructure update, not a user-facing change; README not needed

## Test Plan

- [ ] Push to main and confirm the workflow completes without the Node.js 20 deprecation warning in the Actions run log
- [ ] Verify `deploy-ouimet-info.yml` triggers successfully with the updated appleboy action versions

## Related

Closes https://github.com/couimet/couimet.github.io/issues/28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions used in deployment workflows to enhance deployment reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->