### PR TITLE
[issues/28] Update remaining GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/deploy-ouimet-info.yml
+++ b/.github/workflows/deploy-ouimet-info.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "::add-mask::${{ inputs.password }}"
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/deploy-ouimet-info.yml
+++ b/.github/workflows/deploy-ouimet-info.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "::add-mask::${{ inputs.password }}"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -45,7 +45,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -45,7 +45,7 @@ jobs:
           cache-version: 0 # Increment this number if you need to re-download cached gems
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
@@ -58,7 +58,7 @@ jobs:
         # Overwrites the 'latest' release on every push so the download URL stays stable:
         # https://github.com/couimet/couimet.github.io/releases/latest/download/site.zip
         # Pinned to commit SHA for supply-chain safety (v2 = 3bb12739...)
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: latest
           name: Latest site build


### PR DESCRIPTION
Follow-up to #28: the post-merge workflow run revealed three more actions still flagged for Node.js 20 deprecation.

- actions/checkout@v4 → @v5 (main.yml and deploy-ouimet-info.yml)
- actions/configure-pages@v5 → @v6 (main.yml)
- softprops/action-gh-release SHA bump v2 → v3.0.0 (main.yml)

The actions/upload-artifact warning is transitive (called internally by upload-pages-artifact) and cannot be addressed here.

Part of https://github.com/couimet/couimet.github.io/issues/28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow tooling to use pinned releases and upgraded action versions for improved reliability, stability, and security of build and release processes. No runtime or user-facing application behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->