### PR TITLE
[issues/28] Update `actions/upload-pages-artifact` to `v5.0.0`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
           make_latest: true
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
 
   # Deployment job
   deploy:


### PR DESCRIPTION
This was missed in https://github.com/couimet/couimet.github.io/pull/31.

Ref: https://github.com/couimet/couimet.github.io/pull/31#discussion_r3164151163

Part of https://github.com/couimet/couimet.github.io/issues/28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build and deployment workflow configuration to use the latest version of the artifact upload tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->