### PR TITLE
Revamp `Changelog` versioning

### DIFF
--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -21,11 +21,11 @@
       <p>All notable changes to this project (my career) will be documented in this section.</p>
       <p>The format is based on <a href="https://keepachangelog.com/en/1.1.0/" target="_blank" rel="noopener noreferrer">Keep a Changelog</a> and this project
         adheres to <a href="https://semver.org/spec/v2.0.0.html" target="_blank" rel="noopener noreferrer">Semantic Versioning</a>.</p>
-      <h2 id="changelog-400">4.0.0 - Staff Software Developer @ Shopify (2025-08 to Present)</h2>
-      <h3 id="changelog-400-added">Added</h3>
+      <h2 id="changelog-8-0-0">8.0.0 - Staff Software Developer @ Shopify (2025 to Present)</h2>
+      <h3 id="changelog-8-0-0-added">Added</h3>
       <ul>
         <li>Member of <a href="https://shop.app/" target="_blank" rel="noopener noreferrer">shop.app</a> Buyer Acquisition (growth) team, focused on the <a href="https://help.shop.app/en/shop/shop-cash" target="_blank" rel="noopener noreferrer">Shop Cash</a> domain.</li>
-        <li id="changelog-400-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank" rel="noopener noreferrer">Ruby</a>; ramped up quickly through <a href="https://pragmaticstudio.com/courses/ruby" target="_blank" rel="noopener noreferrer">The Pragmatic Studio</a>'s Ruby Programming course.</li>
+        <li id="changelog-8-0-0-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank" rel="noopener noreferrer">Ruby</a>; ramped up quickly through <a href="https://pragmaticstudio.com/courses/ruby" target="_blank" rel="noopener noreferrer">The Pragmatic Studio</a>'s Ruby Programming course.</li>
         <li>First open source contribution to the <a href="https://rubygems.org/gems/smart_todo/versions/1.11.0" target="_blank" rel="noopener noreferrer">smart_todo</a> gem, adding support for a <code>context</code> attribute referencing GitHub issues (see <a href="https://my.diffend.io/gems/smart_todo/1.10.0/1.11.0" target="_blank" rel="noopener noreferrer">diff</a>).</li>
         <li>Contribution to the transition of the shop.app ecosystem to <a href="https://www.yugabyte.com/" target="_blank" rel="noopener noreferrer">YugabyteDB</a>, including ownership of migration for one of the highest QPS tables (top 20).</li>
         <li>Technical design and implementation of an affiliate payout program in partnership with <a href="https://impact.com/" target="_blank" rel="noopener noreferrer">impact.com</a>.</li>
@@ -53,12 +53,12 @@
         <li>Use of <a href="https://graphite.dev/" target="_blank" rel="noopener noreferrer">Graphite</a>.</li>
         <li>Use of <a href="https://cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Platform</a> (<a href="https://cloud.google.com/bigquery" target="_blank" rel="noopener noreferrer">BigQuery</a> being the one I used the most).</li>
       </ul>
-      <h3 id="changelog-400-deprecated">Deprecated</h3>
+      <h3 id="changelog-8-0-0-deprecated">Deprecated</h3>
       <ul>
         <li>Octav made a company-wide reorg as part of a strategic pivot and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7356644701598371841/" target="_blank" rel="noopener noreferrer">I had to find my next adventure.</a></li>
       </ul>
-      <h2 id="changelog-300">3.0.0 - Principal Software Developer @ Octav (2025-02 to 2025-07)</h2>
-      <h3 id="added">Added</h3>
+      <h2 id="changelog-7-0-0">7.0.0 - Principal Software Developer @ Octav (2025)</h2>
+      <h3 id="changelog-7-0-0-added">Added</h3>
       <ul>
         <li>Transition to crypto/blockchain world; thanks to <a href="https://www.linkedin.com/in/luc-blackburn-32854788/" target="_blank" rel="noopener noreferrer">Luc Blackburn</a> and <a href="https://www.linkedin.com/in/mbaril010/" target="_blank" rel="noopener noreferrer">Mathieu Baril</a> for providing me the opportunity to enter this world.</li>
         <li>Many LinkedIn Learning certificates; <a href="https://www.linkedin.com/in/charlesouimet/details/certifications/" target="_blank" rel="noopener noreferrer">check them out</a>!</li>
@@ -78,23 +78,23 @@
         <li>Centralized <a href="https://github.com/features/actions" target="_blank" rel="noopener noreferrer">GitHub Actions</a> repository to reduce duplication across CI/CD workflows and improve maintainability.</li>
         <li>Structured logging across services, enabling efficient log filtering and analysis via <a href="https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html" target="_blank" rel="noopener noreferrer">AWS CloudWatch Log Insights</a>.</li>
       </ul>
-      <h3 id="deprecated">Deprecated</h3>
+      <h3 id="changelog-7-0-0-deprecated">Deprecated</h3>
       <ul>
         <li>Flexport made a reorg in 2024-10 and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7247719867951255552/" target="_blank" rel="noopener noreferrer">it was my turn to look for a new adventure.</a></li>
       </ul>
-      <h2 id="changelog-240">2.4.0 - Senior Staff Developer @ Flexport (2023-06 to 2024-10)</h2>
-      <h3 id="added-240">Added</h3>
+      <h2 id="changelog-6-2-0">6.2.0 - Senior Staff Developer @ Flexport (2023 to 2024)</h2>
+      <h3 id="changelog-6-2-0-added">Added</h3>
       <ul>
         <li>Integrations between Flexport's freight-forwarding core systems with the newly acquired fulfillment business (known internally as omni-channel).</li>
         <li>Foundation for an abstraction layer to smoothly transition ~80 microservices to <code>AWS SDK V3</code> and out of <code>Node.js v16</code>.</li>
         <li>Knowledge in the global logistics and supply chain industry, focusing on omni-channel fulfillment.</li>
       </ul>
-      <h3 id="deprecated-240">Deprecated</h3>
+      <h3 id="changelog-6-2-0-deprecated">Deprecated</h3>
       <ul>
         <li>Shopify sold its logistics division to Flexport in 2023-06.</li>
       </ul>
-      <h2 id="changelog-230">2.3.0 - Senior Staff Developer @ Shopify Logistics (2022-07 to 2023-06)</h2>
-      <h3 id="added-230">Added</h3>
+      <h2 id="changelog-6-1-0">6.1.0 - Senior Staff Developer @ Shopify Logistics (2022 to 2023)</h2>
+      <h3 id="changelog-6-1-0-added">Added</h3>
       <ul>
         <li>Member of the <code>Technical Leadership Community (TLC)</code>. The mission of our group of 8-10 leaders from across Shopify Logistics' sub-divisions was to guide a team of ~300 developers through the acquisition and standardize best practices. I built presentations and video capsules covering patterns like the transactional outbox, sagas (orchestration vs. choreography), and more.<br />
           The TLC wasn't about enforcing architecture rules; instead, we served as a sounding board, helping teams validate system designs through collaborative discussions. Shout-out to <a href="https://www.linkedin.com/in/jeremiah-brazeau-17282b3/" target="_blank" rel="noopener noreferrer">Jeremiah Brazeau</a> and <a href="https://www.linkedin.com/in/alireza/" target="_blank" rel="noopener noreferrer">Alireza Assadzadeh</a>.
@@ -102,25 +102,25 @@
         <li>Implementation of <code>observability-as-code</code> to streamline the deployment of <a href="https://docs.datadoghq.com/monitors/" target="_blank" rel="noopener noreferrer">DataDog monitors</a> in our <a href="https://en.wikipedia.org/wiki/Continuous_deployment" target="_blank" rel="noopener noreferrer">CD pipelines</a>.</li>
         <li>Knowledge in the logistics industry, working across fulfillment, and supply chain integrations.</li>
       </ul>
-      <h3 id="deprecated-230">Deprecated</h3>
+      <h3 id="changelog-6-1-0-deprecated">Deprecated</h3>
       <ul>
         <li>Shopify acquired Deliverr in 2022-07.</li>
       </ul>
-      <h2 id="changelog-220">2.2.0 - Senior Developer @ Deliverr (2021-12 to 2022-07)</h2>
-      <h3 id="added-220">Added</h3>
+      <h2 id="changelog-6-0-0">6.0.0 - Senior Developer @ Deliverr (2021 to 2022)</h2>
+      <h3 id="changelog-6-0-0-added">Added</h3>
       <ul>
         <li>Use of <a href="https://tsoa-community.github.io/docs/" target="_blank" rel="noopener noreferrer">TSOA</a>; shout-out to <a href="https://www.linkedin.com/in/galtidhar/" target="_blank" rel="noopener noreferrer">Gal Tidhar</a>.</li>
         <li>Use of <a href="https://maxwells-daemon.io/" target="_blank" rel="noopener noreferrer">Maxwell</a> as our <a href="https://en.wikipedia.org/wiki/Change_data_capture" target="_blank" rel="noopener noreferrer">change data capture (CDC)</a> solution.</li>
         <li>Implementation of the <a href="https://microservices.io/patterns/data/transactional-outbox.html" target="_blank" rel="noopener noreferrer">transactional outbox pattern</a> in a brand new service and refactored an already-existing service to use this pattern.</li>
         <li>Definition of the original specification for integration events in our distributed ecosystem, ensuring a robust foundation for inter-service communication.</li>
-        <li>Many contributions to our private packages in the organization's NPM repository; improving developers' expericence across our ecosystem.</li>
+        <li>Many contributions to our private packages in the organization's NPM repository; improving developers' experience across our ecosystem.</li>
         <li>A few small Slack communities/sub-groups focusing on domain-driven design, event-driven architecture, serverless technologies, observability, etc.</li>
         <li>Knowledge in the fulfillment and warehousing industry.</li>
       </ul>
-      <h2 id="changelog-210">2.1.0 - Tech Lead @ SSENSE (2019-10 to 2021-12)</h2>
-      <h3 id="added-210">Added</h3>
+      <h2 id="changelog-5-0-0">5.0.0 - Tech Lead @ SSENSE (2019 to 2021)</h2>
+      <h3 id="changelog-5-0-0-added">Added</h3>
       <ul>
-        <li>Use of <a href="https://en.wikipedia.org/wiki/Domain-driven_design" target="_blank" rel="noopener noreferrer">Domain-Driven Design (<a href="https://www.linkedin.com/feed/hashtag/?keywords=ddd" target="_blank" rel="noopener noreferrer">#ddd</a>); shout-out to <a href="https://www.linkedin.com/in/mbneto/" target="_blank" rel="noopener noreferrer">Mário Bittencourt</a>.</li>
+        <li>Use of <a href="https://en.wikipedia.org/wiki/Domain-driven_design" target="_blank" rel="noopener noreferrer">Domain-Driven Design</a> (<a href="https://www.linkedin.com/feed/hashtag/?keywords=ddd" target="_blank" rel="noopener noreferrer">#ddd</a>); shout-out to <a href="https://www.linkedin.com/in/mbneto/" target="_blank" rel="noopener noreferrer">Mário Bittencourt</a>.</li>
         <li>Use of <a href="https://en.wikipedia.org/wiki/Event-driven_architecture" target="_blank" rel="noopener noreferrer">Event-Driven Architecture (eda)</a>.</li>
         <li>Use of <a href="https://refactoring.guru/design-patterns/state/typescript/example" target="_blank" rel="noopener noreferrer">state machine</a> to manage the state of the customer orders in the newly-peeled-off <a href="https://en.wikipedia.org/wiki/Order_management_system" target="_blank" rel="noopener noreferrer">order management system (OMS)</a>.</li>
         <li>Use of <a href="https://en.wikipedia.org/wiki/SOLID" target="_blank" rel="noopener noreferrer">SOLID principles</a>.</li>
@@ -138,12 +138,12 @@
         <li>Winner of Hackathon 2019 with my idea to improve the onboarding process of new hires.</li>
         <li>Knowledge in the luxury e-commerce industry and distributed order management systems.</li>
       </ul>
-      <h3 id="changed-210">Changed</h3>
+      <h3 id="changelog-5-0-0-changed">Changed</h3>
       <ul>
-        <li>Title/seniority level to <code>Tech Lead</code> in 2020-08; I was originially hired as a <code>Senior Developer</code>.</li>
+        <li>Title/seniority level to <code>Tech Lead</code> in 2020-08; I was originally hired as a <code>Senior Developer</code>.</li>
       </ul>
-      <h2 id="changelog-200">2.0.0 - Senior Developer @ Zola (2019-01 to 2019-10)</h2>
-      <h3 id="added-200">Added</h3>
+      <h2 id="changelog-4-0-0">4.0.0 - Senior Developer @ Zola (2019)</h2>
+      <h3 id="changelog-4-0-0-added">Added</h3>
       <ul>
         <li>Use of <a href="https://aws.amazon.com/" target="_blank" rel="noopener noreferrer">Amazon Web Services (AWS)</a>.</li>
         <li>Use of <a href="https://en.wikipedia.org/wiki/Microservices" target="_blank" rel="noopener noreferrer">microservices</a>.</li>
@@ -153,12 +153,12 @@
         <li>Knowledge in the wedding and event planning industry.</li>
         <li>Knowledge in the e-commerce industry.</li>
       </ul>
-      <h3 id="changed-200">Changed</h3>
+      <h3 id="changelog-4-0-0-changed">Changed</h3>
       <ul>
         <li>The type of companies I worked for; shout-out to <a href="https://www.linkedin.com/in/yavery/" target="_blank" rel="noopener noreferrer">Yan Avery</a> for providing me the opportunity to enter <i>startup world</i>.</li>
       </ul>
-      <h2 id="changelog-120">1.2.0 - Architect @ AFS Technologies (2011-11 to 2018-12)</h2>
-      <h3 id="added-120">Added</h3>
+      <h2 id="changelog-3-0-0">3.0.0 - Architect @ AFS Technologies (2011 to 2018)</h2>
+      <h3 id="changelog-3-0-0-added">Added</h3>
       <ul>
         <li>Skills to develop <a href="https://en.wikipedia.org/wiki/Software_as_a_service" target="_blank" rel="noopener noreferrer">SaaS solutions</a>.</li>
         <li>Use of <a href="https://en.wikipedia.org/wiki/Agile_software_development" target="_blank" rel="noopener noreferrer">Agile methodologies</a>.</li>
@@ -169,23 +169,23 @@
         <li><a href="https://en.wikipedia.org/wiki/Scrum_(software_development)" target="_blank" rel="noopener noreferrer">Scrum Master</a> certification.</li>
         <li>Knowledge in the <a href="https://en.wikipedia.org/wiki/Fast-moving_consumer_goods" target="_blank" rel="noopener noreferrer">consumer packaged goods (CPG)</a> industry.</li>
       </ul>
-      <h3 id="changed-120">Changed</h3>
+      <h3 id="changelog-3-0-0-changed">Changed</h3>
       <ul>
-        <li>Title/seniority level to <code>Architect</code> in 2014-09; I was originially hired as a <code>Senior Developer</code>.</li>
+        <li>Title/seniority level to <code>Architect</code> in 2014-09; I was originally hired as a <code>Senior Developer</code>.</li>
       </ul>
-      <h2 id="changelog-110">1.1.0 - Senior Developer @ Vidéotron (2006-07 to 2011-10)</h2>
-      <h3 id="added-110">Added</h3>
+      <h2 id="changelog-2-0-0">2.0.0 - Senior Developer @ Vidéotron (2006 to 2011)</h2>
+      <h3 id="changelog-2-0-0-added">Added</h3>
       <ul>
         <li>Knowledge in the telecommunications sector (specializing on the <a href="https://www.techtarget.com/searchnetworking/definition/network-management-system" target="_blank" rel="noopener noreferrer">network management system</a>).</li>
       </ul>
-      <h2 id="changelog-100">1.0.0 - Senior Developer @ Markzware Software (2001-03 to 2006-06)</h2>
-      <h3 id="added-100">Added</h3>
+      <h2 id="changelog-1-0-0">1.0.0 - Senior Developer @ Markzware Software (2001 to 2006)</h2>
+      <h3 id="changelog-1-0-0-added">Added</h3>
       <ul>
         <li>Use of <code>C</code>, <code>C++</code>, <code>Perl</code>.</li>
         <li>Knowledge in the digital publishing, prepress and printing industry.</li>
       </ul>
-      <h2 id="changelog-010">0.1.0 - The Beginning (2001)</h2>
-      <h3 id="added-010">Added</h3>
+      <h2 id="changelog-0-1-0">0.1.0 - The Beginning (2001)</h2>
+      <h3 id="changelog-0-1-0-added">Added</h3>
       <ul>
         <li>The beginning of my journey into professional software development with a passion for problem-solving and technology.</li>
       </ul>


### PR DESCRIPTION
Bumps all version numbers to reflect a revised semver scheme (8.0.0 → 1.0.0 top-down), standardises section IDs to `changelog-N-N-N-{added,deprecated,changed}`, simplifies date ranges to year-only, fixes a few typos, and corrects a malformed nested `<a>` tag in the Domain-Driven Design entry.

See https://github.com/couimet/couimet.github.io/pull/33#issuecomment-4359829040 and following comments for the source of those improvements.