### PR TITLE
[issues/34] Fix unzip umask causing HTTP 403 on ouimet.info

### DIFF
--- a/scripts/sync-ouimet-info.sh
+++ b/scripts/sync-ouimet-info.sh
@@ -40,6 +40,7 @@ wget -q --show-progress -O "$ZIP_TMP" "$RELEASE_URL"
 
 echo "==> Extracting into staging directory"
 unzip -q "$ZIP_TMP" -d "$STAGING_DIR"
+chmod -R a+rX "$STAGING_DIR"
 
 echo "==> Syncing into $REMOTE_PATH (files removed from the build will be deleted)"
 rsync -a --delete \
@@ -47,6 +48,7 @@ rsync -a --delete \
   --exclude 'sarah/' \
   --exclude '.htaccess' \
   "$STAGING_DIR"/ "$REMOTE_PATH"/
+chmod o+rx "$REMOTE_PATH"
 
 echo ""
 echo "==> Done. ouimet.info web root is now up to date."


### PR DESCRIPTION
## Summary

When `unzip` runs on the server, the process's restrictive `umask` can produce directories with `drwx------` permissions. Because `rsync -a` preserves source permissions, those restrictions carry over to `$REMOTE_PATH`, blocking the web server (which runs as a different user) and returning HTTP 403. Two `chmod` calls — one before `rsync`, one after — close both vectors.

## Changes

- After `unzip`, add `chmod -R a+rX "$STAGING_DIR"` to normalize all extracted content to world-readable before `rsync` copies permissions to the web root
- After `rsync`, add `chmod o+rx "$REMOTE_PATH"` as a belt-and-suspenders guarantee that the web root directory itself is always traversable
- Documentation: CHANGELOG not needed — operational server script, not a user-facing feature; README not needed

## Test Plan

- [ ] All existing tests pass (Jekyll build succeeds)
- [ ] Manual testing: run `sync-ouimet-info.sh` on the server and confirm `ouimet_info/` has `drwxr-xr-x` and https://ouimet.info returns 200

## Related

Closes https://github.com/couimet/couimet.github.io/issues/34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved filesystem permission handling in the sync process. File permissions are now properly configured after extraction and synchronization to ensure appropriate access levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->