### PR TITLE
[issues/41] Add hover anchor links to section titles and changelog headings

### DIFF
--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -3,8 +3,14 @@
     <div class="row mb-3">
       <div class="col-md-6">
         <h1 class="display-4 text-start section-title">
-          <a href="#articles" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
-          <a class="text-reset" href="{{ '/articles/' | prepend: site.baseurl }}">Articles</a>
+          {% if page.url == '/' %}
+            <a href="#articles" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
+          {% endif %}
+          {% if page.url == '/articles/' %}
+            Articles
+          {% else %}
+            <a class="text-reset" href="{{ '/articles/' | prepend: site.baseurl }}">Articles</a>
+          {% endif %}
         </h1>
       </div>
     </div>

--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -2,7 +2,8 @@
   <div class="container">
     <div class="row mb-3">
       <div class="col-md-6">
-        <h1 class="display-4 text-start">
+        <h1 class="display-4 text-start section-title">
+          <a href="#articles" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
           <a class="text-reset" href="{{ '/articles/' | prepend: site.baseurl }}">Articles</a>
         </h1>
       </div>
@@ -79,6 +80,7 @@
       var url = window.location.origin + window.location.pathname + "#" + anchor;
       if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
         showShareToast(btn, "Copy failed");
+        btn.blur();
         return;
       }
       navigator.clipboard.writeText(url).then(function () {
@@ -86,19 +88,24 @@
       }).catch(function () {
         showShareToast(btn, "Copy failed");
       });
+      btn.blur();
     }
 
     function showShareToast(btn, text) {
       var existing = btn.parentElement.querySelector(".article-share-toast");
       if (existing) existing.remove();
+      btn.style.opacity = "1";
       var toast = document.createElement("span");
       toast.className = "article-share-toast";
       toast.setAttribute("role", "status");
       toast.setAttribute("aria-live", "polite");
       toast.setAttribute("aria-atomic", "true");
       toast.textContent = text;
-      btn.insertAdjacentElement("afterend", toast);
-      setTimeout(function () { toast.remove(); }, 1500);
+      btn.appendChild(toast);
+      setTimeout(function () {
+        toast.remove();
+        btn.style.opacity = "";
+      }, 1500);
     }
 
     var articleUserScrolled = false;

--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -52,6 +52,7 @@
   </div>
 </div>
 
+{% include copy-link.html %}
 <script>
   (function () {
     function revealAnchoredArticle() {
@@ -63,10 +64,10 @@
       if (!el) return;
 
       var prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      el.classList.remove("pulse");
+      el.classList.remove("anchor-pulse");
       void el.offsetWidth;
-      el.classList.add("pulse");
-      setTimeout(function () { el.classList.remove("pulse"); }, prefersReduced ? 2000 : 6000);
+      el.classList.add("anchor-pulse");
+      setTimeout(function () { el.classList.remove("anchor-pulse"); }, prefersReduced ? 2000 : 6000);
 
       el.scrollIntoView({ behavior: prefersReduced ? "auto" : "smooth", block: "nearest" });
     }
@@ -78,34 +79,7 @@
       var anchor = btn.getAttribute("data-anchor");
       if (!anchor) return;
       var url = window.location.origin + window.location.pathname + "#" + anchor;
-      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
-        showShareToast(btn, "Copy failed");
-        btn.blur();
-        return;
-      }
-      navigator.clipboard.writeText(url).then(function () {
-        showShareToast(btn, "Copied");
-      }).catch(function () {
-        showShareToast(btn, "Copy failed");
-      });
-      btn.blur();
-    }
-
-    function showShareToast(btn, text) {
-      var existing = btn.parentElement.querySelector(".article-share-toast");
-      if (existing) existing.remove();
-      btn.style.opacity = "1";
-      var toast = document.createElement("span");
-      toast.className = "article-share-toast";
-      toast.setAttribute("role", "status");
-      toast.setAttribute("aria-live", "polite");
-      toast.setAttribute("aria-atomic", "true");
-      toast.textContent = text;
-      btn.appendChild(toast);
-      setTimeout(function () {
-        toast.remove();
-        btn.style.opacity = "";
-      }, 1500);
+      copyLink(btn, url);
     }
 
     var articleUserScrolled = false;

--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -216,42 +216,17 @@
   </div>
 </div>
 
+{% include copy-link.html %}
 <script>
   (function () {
     function handleHeadingAnchorClick(e) {
       var anchor = e.target.closest(".heading-anchor");
       if (!anchor) return;
-      e.preventDefault();
       var id = anchor.getAttribute("href");
       if (!id || !id.startsWith("#")) return;
+      e.preventDefault();
       var url = window.location.origin + window.location.pathname + id;
-      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
-        showHeadingToast(anchor, "Copy failed");
-        return;
-      }
-      navigator.clipboard.writeText(url).then(function () {
-        showHeadingToast(anchor, "Copied");
-      }).catch(function () {
-        showHeadingToast(anchor, "Copy failed");
-      });
-      anchor.blur();
-    }
-
-    function showHeadingToast(anchor, text) {
-      var existing = anchor.parentElement.querySelector(".heading-anchor-toast");
-      if (existing) existing.remove();
-      anchor.style.opacity = "1";
-      var toast = document.createElement("span");
-      toast.className = "heading-anchor-toast";
-      toast.setAttribute("role", "status");
-      toast.setAttribute("aria-live", "polite");
-      toast.setAttribute("aria-atomic", "true");
-      toast.textContent = text;
-      anchor.appendChild(toast);
-      setTimeout(function () {
-        toast.remove();
-        anchor.style.opacity = "";
-      }, 1500);
+      copyLink(anchor, url);
     }
 
     function revealHeadingFromHash() {
@@ -265,10 +240,10 @@
       var prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       // Defer to ensure browser has finished native scroll-to-fragment before we pulse
       requestAnimationFrame(function () {
-        el.classList.remove("heading-pulse");
+        el.classList.remove("anchor-pulse");
         void el.offsetWidth;
-        el.classList.add("heading-pulse");
-        setTimeout(function () { el.classList.remove("heading-pulse"); }, prefersReduced ? 2000 : 6000);
+        el.classList.add("anchor-pulse");
+        setTimeout(function () { el.classList.remove("anchor-pulse"); }, prefersReduced ? 2000 : 6000);
       });
     }
 

--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -219,16 +219,6 @@
 {% include copy-link.html %}
 <script>
   (function () {
-    function handleHeadingAnchorClick(e) {
-      var anchor = e.target.closest(".heading-anchor");
-      if (!anchor) return;
-      var id = anchor.getAttribute("href");
-      if (!id || !id.startsWith("#")) return;
-      e.preventDefault();
-      var url = window.location.origin + window.location.pathname + id;
-      copyLink(anchor, url);
-    }
-
     function revealHeadingFromHash() {
       if (!window.location.hash) return;
       var id = window.location.hash.slice(1);
@@ -263,7 +253,6 @@
       }
     }
 
-    document.addEventListener("click", handleHeadingAnchorClick);
     window.addEventListener("DOMContentLoaded", function () {
       injectAnchors();
       revealHeadingFromHash();

--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -2,7 +2,8 @@
   <div class="container">
     <div class="row mb-3">
       <div class="col-md-6">
-        <h1 class="display-4 text-start">
+        <h1 class="display-4 text-start section-title">
+          <a href="#career-changelog" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
           <a class="text-reset" href="{{ '/career/changelog/' | prepend: site.baseurl }}">Career Changelog</a>
         </h1>
       </div>
@@ -21,8 +22,8 @@
       <p>All notable changes to this project (my career) will be documented in this section.</p>
       <p>The format is based on <a href="https://keepachangelog.com/en/1.1.0/" target="_blank" rel="noopener noreferrer">Keep a Changelog</a> and this project
         adheres to <a href="https://semver.org/spec/v2.0.0.html" target="_blank" rel="noopener noreferrer">Semantic Versioning</a>.</p>
-      <h2 id="changelog-8-0-0">8.0.0 - Staff Software Developer @ Shopify (2025 to 2026)</h2>
-      <h3 id="changelog-8-0-0-added">Added</h3>
+      <h2 id="changelog-8-0-0"><a href="#changelog-8-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>8.0.0 - Staff Software Developer @ Shopify (2025 to 2026)</h2>
+      <h3 id="changelog-8-0-0-added"><a href="#changelog-8-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Member of <a href="https://shop.app/" target="_blank" rel="noopener noreferrer">shop.app</a> Buyer Acquisition (growth) team, focused on the <a href="https://help.shop.app/en/shop/shop-cash" target="_blank" rel="noopener noreferrer">Shop Cash</a> domain.</li>
         <li>First open source contribution to the <a href="https://rubygems.org/gems/smart_todo/versions/1.11.0" target="_blank" rel="noopener noreferrer">smart_todo</a> gem, adding support for a <code>context</code> attribute referencing GitHub issues (see <a href="https://my.diffend.io/gems/smart_todo/1.10.0/1.11.0" target="_blank" rel="noopener noreferrer">diff</a>).</li>
@@ -36,8 +37,8 @@
             <li>Motivated the creation of <a href="https://ouimet.info/projects/rangelink-extension.html" target="_blank" rel="noopener noreferrer">RangeLink</a> and <a href="https://ouimet.info/projects/my-claude-skills.html" target="_blank" rel="noopener noreferrer">my-claude-skills</a>.</li>
           </ul>
         </li>
-        <li id="changelog-8-0-0-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank" rel="noopener noreferrer">Ruby</a>; ramped up quickly through <a href="https://pragmaticstudio.com/courses/ruby" target="_blank" rel="noopener noreferrer">The Pragmatic Studio</a>'s Ruby Programming course.</li>
-        <li>Use of <a href="https://rubyonrails.org/" target="_blank" rel="noopener noreferrer">Ruby on Rails</a> and related ecosystem:
+        <li id="changelog-added-ruby">Use of <a href="https://www.ruby-lang.org/" target="_blank" rel="noopener noreferrer">Ruby</a>; ramped up quickly through <a href="https://pragmaticstudio.com/courses/ruby" target="_blank" rel="noopener noreferrer">The Pragmatic Studio</a>'s Ruby Programming course.</li>
+        <li id="changelog-added-ruby-on-rails">Use of <a href="https://rubyonrails.org/" target="_blank" rel="noopener noreferrer">Ruby on Rails</a> and related ecosystem:
           <ul>
             <li><a href="https://guides.rubyonrails.org/active_record_basics.html" target="_blank" rel="noopener noreferrer">ActiveRecord</a></li>
             <li><a href="https://guides.rubyonrails.org/active_job_basics.html" target="_blank" rel="noopener noreferrer">ActiveJob</a></li>
@@ -54,12 +55,12 @@
         <li>Use of <a href="https://buildkite.com/" target="_blank" rel="noopener noreferrer">Buildkite</a>.</li>
         <li>Use of <a href="https://cloud.google.com/" target="_blank" rel="noopener noreferrer">Google Cloud Platform</a> (<a href="https://cloud.google.com/bigquery" target="_blank" rel="noopener noreferrer">BigQuery</a> being the one I used the most).</li>
       </ul>
-      <h3 id="changelog-8-0-0-deprecated">Deprecated</h3>
+      <h3 id="changelog-8-0-0-deprecated"><a href="#changelog-8-0-0-deprecated" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Deprecated</h3>
       <ul>
         <li>Octav made a company-wide reorg as part of a strategic pivot and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7356644701598371841/" target="_blank" rel="noopener noreferrer">I had to find my next adventure.</a></li>
       </ul>
-      <h2 id="changelog-7-0-0">7.0.0 - Principal Software Developer @ Octav (2025)</h2>
-      <h3 id="changelog-7-0-0-added">Added</h3>
+      <h2 id="changelog-7-0-0"><a href="#changelog-7-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>7.0.0 - Principal Software Developer @ Octav (2025)</h2>
+      <h3 id="changelog-7-0-0-added"><a href="#changelog-7-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Transition to crypto/blockchain world; thanks to <a href="https://www.linkedin.com/in/luc-blackburn-32854788/" target="_blank" rel="noopener noreferrer">Luc Blackburn</a> and <a href="https://www.linkedin.com/in/mbaril010/" target="_blank" rel="noopener noreferrer">Mathieu Baril</a> for providing me the opportunity to enter this world.</li>
         <li>Many LinkedIn Learning certificates; <a href="https://www.linkedin.com/in/charlesouimet/details/certifications/" target="_blank" rel="noopener noreferrer">check them out</a>!</li>
@@ -85,23 +86,23 @@
         <li>Use of <a href="https://sequelize.org/" target="_blank" rel="noopener noreferrer">Sequelize</a>.</li>
         <li>Use of <a href="https://sentry.io/" target="_blank" rel="noopener noreferrer">Sentry</a>.</li>
       </ul>
-      <h3 id="changelog-7-0-0-deprecated">Deprecated</h3>
+      <h3 id="changelog-7-0-0-deprecated"><a href="#changelog-7-0-0-deprecated" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Deprecated</h3>
       <ul>
         <li>Flexport made a reorg in 2024-10 and <a href="https://www.linkedin.com/feed/update/urn:li:activity:7247719867951255552/" target="_blank" rel="noopener noreferrer">it was my turn to look for a new adventure.</a></li>
       </ul>
-      <h2 id="changelog-6-2-0">6.2.0 - Senior Staff Developer @ Flexport (2023 to 2024)</h2>
-      <h3 id="changelog-6-2-0-added">Added</h3>
+      <h2 id="changelog-6-2-0"><a href="#changelog-6-2-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>6.2.0 - Senior Staff Developer @ Flexport (2023 to 2024)</h2>
+      <h3 id="changelog-6-2-0-added"><a href="#changelog-6-2-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Integrations between Flexport's freight-forwarding core systems with the newly acquired fulfillment business (known internally as omni-channel).</li>
         <li>Foundation for an abstraction layer to smoothly transition ~80 microservices to <code>AWS SDK V3</code> and out of <code>Node.js v16</code>.</li>
         <li>Knowledge in the global logistics and supply chain industry, focusing on omni-channel fulfillment.</li>
       </ul>
-      <h3 id="changelog-6-2-0-deprecated">Deprecated</h3>
+      <h3 id="changelog-6-2-0-deprecated"><a href="#changelog-6-2-0-deprecated" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Deprecated</h3>
       <ul>
         <li>Shopify sold its logistics division to Flexport in 2023-06.</li>
       </ul>
-      <h2 id="changelog-6-1-0">6.1.0 - Senior Staff Developer @ Shopify Logistics (2022 to 2023)</h2>
-      <h3 id="changelog-6-1-0-added">Added</h3>
+      <h2 id="changelog-6-1-0"><a href="#changelog-6-1-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>6.1.0 - Senior Staff Developer @ Shopify Logistics (2022 to 2023)</h2>
+      <h3 id="changelog-6-1-0-added"><a href="#changelog-6-1-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Member of the <code>Technical Leadership Community (TLC)</code>. The mission of our group of 8-10 leaders from across Shopify Logistics' sub-divisions was to guide a team of ~300 developers through the acquisition and standardize best practices. I built presentations and video capsules covering patterns like the transactional outbox, sagas (orchestration vs. choreography), and more.<br />
           The TLC wasn't about enforcing architecture rules; instead, we served as a sounding board, helping teams validate system designs through collaborative discussions. Shout-out to <a href="https://www.linkedin.com/in/jeremiah-brazeau-17282b3/" target="_blank" rel="noopener noreferrer">Jeremiah Brazeau</a> and <a href="https://www.linkedin.com/in/alireza/" target="_blank" rel="noopener noreferrer">Alireza Assadzadeh</a>.
@@ -109,12 +110,12 @@
         <li>Implementation of <code>observability-as-code</code> to streamline the deployment of <a href="https://docs.datadoghq.com/monitors/" target="_blank" rel="noopener noreferrer">DataDog monitors</a> in our <a href="https://en.wikipedia.org/wiki/Continuous_deployment" target="_blank" rel="noopener noreferrer">CD pipelines</a>.</li>
         <li>Knowledge in the logistics industry, working across fulfillment, and supply chain integrations.</li>
       </ul>
-      <h3 id="changelog-6-1-0-deprecated">Deprecated</h3>
+      <h3 id="changelog-6-1-0-deprecated"><a href="#changelog-6-1-0-deprecated" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Deprecated</h3>
       <ul>
         <li>Shopify acquired Deliverr in 2022-07.</li>
       </ul>
-      <h2 id="changelog-6-0-0">6.0.0 - Senior Developer @ Deliverr (2021 to 2022)</h2>
-      <h3 id="changelog-6-0-0-added">Added</h3>
+      <h2 id="changelog-6-0-0"><a href="#changelog-6-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>6.0.0 - Senior Developer @ Deliverr (2021 to 2022)</h2>
+      <h3 id="changelog-6-0-0-added"><a href="#changelog-6-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Implementation of the <a href="https://microservices.io/patterns/data/transactional-outbox.html" target="_blank" rel="noopener noreferrer">transactional outbox pattern</a> in a brand new service and refactored an already-existing service to use this pattern.</li>
         <li>Definition of the original specification for integration events in our distributed ecosystem, ensuring a robust foundation for inter-service communication.</li>
@@ -129,8 +130,8 @@
         <li>Use of <a href="https://esbuild.github.io/" target="_blank" rel="noopener noreferrer">esbuild</a>.</li>
         <li>Use of <a href="https://www.split.io/" target="_blank" rel="noopener noreferrer">split.io</a>.</li>
       </ul>
-      <h2 id="changelog-5-0-0">5.0.0 - Tech Lead @ SSENSE (2019 to 2021)</h2>
-      <h3 id="changelog-5-0-0-added">Added</h3>
+      <h2 id="changelog-5-0-0"><a href="#changelog-5-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>5.0.0 - Tech Lead @ SSENSE (2019 to 2021)</h2>
+      <h3 id="changelog-5-0-0-added"><a href="#changelog-5-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Project to peel-off the <a href="https://en.wikipedia.org/wiki/Order_management_system" target="_blank" rel="noopener noreferrer">order management system (OMS)</a> out of the company's <a href="https://en.wikipedia.org/wiki/Monolithic_application" target="_blank" rel="noopener noreferrer">monolith</a> to its own DDD domain/microservices.</li>
         <li>Member of <code>Technical Architecture Group (TAG)</code>. With the architects, Staff & Principal Engineers, our group of 6-10 people established the departments' tech standards. Oversaw the projects of 3 other teams to ensure they followed the established standards while still applying best practices to reach the targeted software <i>*ilities</i>.</li>
@@ -158,12 +159,12 @@
         <li>Use of <a href="https://redux.js.org/" target="_blank" rel="noopener noreferrer">Redux</a>.</li>
         <li>Use of <a href="https://launchdarkly.com/" target="_blank" rel="noopener noreferrer">LaunchDarkly</a>.</li>
       </ul>
-      <h3 id="changelog-5-0-0-changed">Changed</h3>
+      <h3 id="changelog-5-0-0-changed"><a href="#changelog-5-0-0-changed" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Changed</h3>
       <ul>
         <li>Title/seniority level to <code>Tech Lead</code> in 2020-08; I was originally hired as a <code>Senior Developer</code>.</li>
       </ul>
-      <h2 id="changelog-4-0-0">4.0.0 - Senior Developer @ Zola (2019)</h2>
-      <h3 id="changelog-4-0-0-added">Added</h3>
+      <h2 id="changelog-4-0-0"><a href="#changelog-4-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>4.0.0 - Senior Developer @ Zola (2019)</h2>
+      <h3 id="changelog-4-0-0-added"><a href="#changelog-4-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li><a href="https://aws.amazon.com/certification/certified-cloud-practitioner/" target="_blank" rel="noopener noreferrer">AWS Certified Cloud Practitioner</a> certification <a href="https://www.credly.com/badges/c3ccd5a7-dc9e-433d-95c5-5a8278a00b60/" target="_blank" rel="noopener noreferrer">issued on 2019-04-19</a>.</li>
         <li>Knowledge in the wedding and event planning industry.</li>
@@ -175,12 +176,12 @@
         <li>Use of <a href="https://docs.ansible.com/" target="_blank" rel="noopener noreferrer">Ansible</a>.</li>
         <li>Use of <a href="https://github.com/google/guice/" target="_blank" rel="noopener noreferrer">Guice</a>.</li>
       </ul>
-      <h3 id="changelog-4-0-0-changed">Changed</h3>
+      <h3 id="changelog-4-0-0-changed"><a href="#changelog-4-0-0-changed" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Changed</h3>
       <ul>
         <li>The type of companies I worked for; shout-out to <a href="https://www.linkedin.com/in/yavery/" target="_blank" rel="noopener noreferrer">Yan Avery</a> for providing me the opportunity to enter <i>startup world</i>.</li>
       </ul>
-      <h2 id="changelog-3-0-0">3.0.0 - Architect @ AFS Technologies (2011 to 2018)</h2>
-      <h3 id="changelog-3-0-0-added">Added</h3>
+      <h2 id="changelog-3-0-0"><a href="#changelog-3-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>3.0.0 - Architect @ AFS Technologies (2011 to 2018)</h2>
+      <h3 id="changelog-3-0-0-added"><a href="#changelog-3-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li><a href="https://en.wikipedia.org/wiki/Scrum_(software_development)" target="_blank" rel="noopener noreferrer">Scrum Master</a> certification.</li>
         <li>Use of <a href="https://en.wikipedia.org/wiki/Agile_software_development" target="_blank" rel="noopener noreferrer">Agile methodologies</a>.</li>
@@ -191,26 +192,107 @@
         <li>Use of <a href="https://en.wikipedia.org/wiki/Continuous_integration" target="_blank" rel="noopener noreferrer">Continuous Integration (CI)</a> pipelines.</li>
         <li>Use of <a href="https://en.wikipedia.org/wiki/Extract,_transform,_load" target="_blank" rel="noopener noreferrer">ETL (Extract, Transform, Load)</a> processes and <a href="https://en.wikipedia.org/wiki/MultiDimensional_eXpressions" target="_blank" rel="noopener noreferrer">MDX query language</a> in a <a href="https://en.wikipedia.org/wiki/Microsoft_Analysis_Services" target="_blank" rel="noopener noreferrer">Microsoft SQL Server Analysis Services (SSAS)</a> environment.</li>        
       </ul>
-      <h3 id="changelog-3-0-0-changed">Changed</h3>
+      <h3 id="changelog-3-0-0-changed"><a href="#changelog-3-0-0-changed" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Changed</h3>
       <ul>
         <li>Title/seniority level to <code>Architect</code> in 2014-09; I was originally hired as a <code>Senior Developer</code>.</li>
       </ul>
-      <h2 id="changelog-2-0-0">2.0.0 - Senior Developer @ Vidéotron (2006 to 2011)</h2>
-      <h3 id="changelog-2-0-0-added">Added</h3>
+      <h2 id="changelog-2-0-0"><a href="#changelog-2-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>2.0.0 - Senior Developer @ Vidéotron (2006 to 2011)</h2>
+      <h3 id="changelog-2-0-0-added"><a href="#changelog-2-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Knowledge in the telecommunications sector (specializing on the <a href="https://www.techtarget.com/searchnetworking/definition/network-management-system" target="_blank" rel="noopener noreferrer">network management system</a>).</li>
       </ul>
-      <h2 id="changelog-1-0-0">1.0.0 - Senior Developer @ Markzware Software (2001 to 2006)</h2>
-      <h3 id="changelog-1-0-0-added">Added</h3>
+      <h2 id="changelog-1-0-0"><a href="#changelog-1-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>1.0.0 - Senior Developer @ Markzware Software (2001 to 2006)</h2>
+      <h3 id="changelog-1-0-0-added"><a href="#changelog-1-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>Knowledge in the digital publishing, prepress and printing industry.</li>
         <li>Use of <code>C</code>, <code>C++</code>, <code>Perl</code>.</li>
       </ul>
-      <h2 id="changelog-0-1-0">0.1.0 - The Beginning (2001)</h2>
-      <h3 id="changelog-0-1-0-added">Added</h3>
+      <h2 id="changelog-0-1-0"><a href="#changelog-0-1-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>0.1.0 - The Beginning (2001)</h2>
+      <h3 id="changelog-0-1-0-added"><a href="#changelog-0-1-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>
         <li>The beginning of my journey into professional software development with a passion for problem-solving and technology.</li>
       </ul>
     </div>
   </div>
 </div>
+
+<script>
+  (function () {
+    function handleHeadingAnchorClick(e) {
+      var anchor = e.target.closest(".heading-anchor");
+      if (!anchor) return;
+      e.preventDefault();
+      var id = anchor.getAttribute("href");
+      if (!id || !id.startsWith("#")) return;
+      var url = window.location.origin + window.location.pathname + id;
+      if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+        showHeadingToast(anchor, "Copy failed");
+        return;
+      }
+      navigator.clipboard.writeText(url).then(function () {
+        showHeadingToast(anchor, "Copied");
+      }).catch(function () {
+        showHeadingToast(anchor, "Copy failed");
+      });
+      anchor.blur();
+    }
+
+    function showHeadingToast(anchor, text) {
+      var existing = anchor.parentElement.querySelector(".heading-anchor-toast");
+      if (existing) existing.remove();
+      anchor.style.opacity = "1";
+      var toast = document.createElement("span");
+      toast.className = "heading-anchor-toast";
+      toast.setAttribute("role", "status");
+      toast.setAttribute("aria-live", "polite");
+      toast.setAttribute("aria-atomic", "true");
+      toast.textContent = text;
+      anchor.appendChild(toast);
+      setTimeout(function () {
+        toast.remove();
+        anchor.style.opacity = "";
+      }, 1500);
+    }
+
+    function revealHeadingFromHash() {
+      if (!window.location.hash) return;
+      var id = window.location.hash.slice(1);
+      if (!id || !id.startsWith("changelog-")) return;
+
+      var el = document.getElementById(id);
+      if (!el) return;
+
+      var prefersReduced = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      // Defer to ensure browser has finished native scroll-to-fragment before we pulse
+      requestAnimationFrame(function () {
+        el.classList.remove("heading-pulse");
+        void el.offsetWidth;
+        el.classList.add("heading-pulse");
+        setTimeout(function () { el.classList.remove("heading-pulse"); }, prefersReduced ? 2000 : 6000);
+      });
+    }
+
+    function injectAnchors() {
+      var container = document.querySelector("#career-changelog");
+      if (!container) return;
+      var elements = container.querySelectorAll("[id^='changelog-']");
+      for (var i = 0; i < elements.length; i++) {
+        var el = elements[i];
+        if (el.querySelector(".heading-anchor")) continue;
+        var anchor = document.createElement("a");
+        anchor.href = "#" + el.id;
+        anchor.className = "heading-anchor";
+        anchor.setAttribute("aria-label", "Copy link to this section");
+        anchor.textContent = "🔗";
+        el.insertBefore(anchor, el.firstChild);
+      }
+    }
+
+    document.addEventListener("click", handleHeadingAnchorClick);
+    window.addEventListener("DOMContentLoaded", function () {
+      injectAnchors();
+      revealHeadingFromHash();
+    });
+    window.addEventListener("hashchange", revealHeadingFromHash);
+  })();
+</script>

--- a/_includes/copy-link.html
+++ b/_includes/copy-link.html
@@ -1,0 +1,30 @@
+<script>
+  window.copyLink = function (trigger, url) {
+    function showToast(text) {
+      var existing = trigger.querySelector(".copy-link-toast");
+      if (existing) existing.remove();
+      trigger.style.opacity = "1";
+      var toast = document.createElement("span");
+      toast.className = "copy-link-toast";
+      toast.setAttribute("role", "status");
+      toast.setAttribute("aria-live", "polite");
+      toast.setAttribute("aria-atomic", "true");
+      toast.textContent = text;
+      trigger.appendChild(toast);
+      setTimeout(function () { toast.remove(); trigger.style.opacity = ""; }, 1500);
+    }
+
+    if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
+      showToast("Copy failed");
+      trigger.blur();
+      return;
+    }
+
+    navigator.clipboard.writeText(url).then(function () {
+      showToast("Copied");
+    }).catch(function () {
+      showToast("Copy failed");
+    });
+    trigger.blur();
+  };
+</script>

--- a/_includes/copy-link.html
+++ b/_includes/copy-link.html
@@ -1,6 +1,9 @@
 <script>
   window.copyLink = function (trigger, url) {
     function showToast(text) {
+      if (trigger._copyLinkToastTimer) {
+        clearTimeout(trigger._copyLinkToastTimer);
+      }
       var existing = trigger.querySelector(".copy-link-toast");
       if (existing) existing.remove();
       trigger.style.opacity = "1";
@@ -11,7 +14,11 @@
       toast.setAttribute("aria-atomic", "true");
       toast.textContent = text;
       trigger.appendChild(toast);
-      setTimeout(function () { toast.remove(); trigger.style.opacity = ""; }, 1500);
+      trigger._copyLinkToastTimer = setTimeout(function () {
+        toast.remove();
+        trigger.style.opacity = "";
+        trigger._copyLinkToastTimer = null;
+      }, 1500);
     }
 
     if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
@@ -27,4 +34,17 @@
     });
     trigger.blur();
   };
+
+  if (!window._copyLinkHeadingHandlerRegistered) {
+    window._copyLinkHeadingHandlerRegistered = true;
+    document.addEventListener("click", function (e) {
+      var anchor = e.target.closest(".heading-anchor");
+      if (!anchor) return;
+      var id = anchor.getAttribute("href");
+      if (!id || !id.startsWith("#")) return;
+      e.preventDefault();
+      var url = window.location.origin + window.location.pathname + id;
+      copyLink(anchor, url);
+    });
+  }
 </script>

--- a/_includes/follow-alongs/follow-alongs.html
+++ b/_includes/follow-alongs/follow-alongs.html
@@ -3,8 +3,14 @@
     <div class="row mb-3">
       <div class="col-md-12">
         <h1 class="display-4 text-start section-title">
-          <a href="#follow-alongs" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
-          <a class="text-reset" href="{{ '/follow-alongs/' | prepend: site.baseurl }}">Follow-alongs</a>
+          {% if page.url == '/' %}
+            <a href="#follow-alongs" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
+          {% endif %}
+          {% if page.url == '/follow-alongs/' %}
+            Follow-alongs
+          {% else %}
+            <a class="text-reset" href="{{ '/follow-alongs/' | prepend: site.baseurl }}">Follow-alongs</a>
+          {% endif %}
         </h1>
         <div>
           <p>
@@ -33,5 +39,6 @@
       <p class="text-center pt-4"><a href="{{ site.baseurl}}/follow-alongs/">See all {{ follow-along_pages.size }} follow-alongs</a></p>
     {% endif %}
 
+{% include copy-link.html %}
   </div>
 </div>

--- a/_includes/follow-alongs/follow-alongs.html
+++ b/_includes/follow-alongs/follow-alongs.html
@@ -2,7 +2,8 @@
   <div class="container">
     <div class="row mb-3">
       <div class="col-md-12">
-        <h1 class="display-4 text-start">
+        <h1 class="display-4 text-start section-title">
+          <a href="#follow-alongs" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
           <a class="text-reset" href="{{ '/follow-alongs/' | prepend: site.baseurl }}">Follow-alongs</a>
         </h1>
         <div>

--- a/_includes/projects/projects.html
+++ b/_includes/projects/projects.html
@@ -3,8 +3,14 @@
     <div class="row mb-3">
       <div class="col-md-6">
         <h1 class="display-4 text-start section-title">
-          <a href="#projects" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
-          <a class="text-reset" href="{{ '/projects/' | prepend: site.baseurl }}">Projects</a>
+          {% if page.url == '/' %}
+            <a href="#projects" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
+          {% endif %}
+          {% if page.url == '/projects/' %}
+            Projects
+          {% else %}
+            <a class="text-reset" href="{{ '/projects/' | prepend: site.baseurl }}">Projects</a>
+          {% endif %}
         </h1>
       </div>
     </div>
@@ -32,5 +38,6 @@
       <p class="text-center pt-4"><a href="{{ site.baseurl}}/projects/">See all {{ not_draft }} projects</a></p>
     {% endif %}
 
+{% include copy-link.html %}
   </div>
 </div>

--- a/_includes/projects/projects.html
+++ b/_includes/projects/projects.html
@@ -2,7 +2,8 @@
   <div class="container">
     <div class="row mb-3">
       <div class="col-md-6">
-        <h1 class="display-4 text-start">
+        <h1 class="display-4 text-start section-title">
+          <a href="#projects" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
           <a class="text-reset" href="{{ '/projects/' | prepend: site.baseurl }}">Projects</a>
         </h1>
       </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -17,6 +17,7 @@ layout: default
     var userHasScrolled = false;
     var currentSectionHash = "";
     var ticking = false;
+    var loadSuppressUntil = Date.now() + 500;
 
     function getActiveSection() {
       // Active = last section whose top is above 20% of the viewport.
@@ -32,6 +33,7 @@ layout: default
     function updateHash() {
       ticking = false;
       if (!userHasScrolled) return;
+      if (Date.now() < loadSuppressUntil) return;
 
       var active = getActiveSection();
 
@@ -44,8 +46,13 @@ layout: default
       }
 
       var id = active.id;
-      // Don't clobber an article-level hash when re-entering the articles section
-      if (id === "articles" && window.location.hash.startsWith("#article-")) return;
+      // Don't clobber a sub-section hash when its parent section becomes active
+      if (window.location.hash) {
+        if ((id === "articles" && window.location.hash.startsWith("#article-")) ||
+            (id === "career-changelog" && window.location.hash.startsWith("#changelog-"))) {
+          return;
+        }
+      }
 
       // "about" is the implicit top — keep the URL clean with no hash
       if (id === "about") {

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -113,6 +113,7 @@ a {
   opacity: 0;
   transition: opacity 0.15s ease, background-color 0.15s ease;
   border-radius: 3px;
+  position: relative;
 }
 
 .article-item:hover .article-share,
@@ -134,22 +135,24 @@ a {
 }
 
 .article-share-toast {
-  display: inline-block;
-  margin-left: 2px;
-  background: var(--tf-articles-toast-bg-color);
-  color: var(--tf-articles-toast-fg-color);
+  position: absolute;
+  left: 100%;
+  top: 0;
+  white-space: nowrap;
+  background: #0d6efd;
+  color: #ffffff;
   border: none;
   border-radius: 4px;
   padding: 1px 8px;
   font-size: 0.7rem;
+  font-weight: 500;
   pointer-events: none;
   animation: article-share-toast-fade 1.5s ease forwards;
-  vertical-align: middle;
 }
 
 @keyframes article-share-toast-fade {
   0%   { opacity: 0; transform: translateX(4px); }
-  15%  { opacity: 1; transform: translateX(0); }
+  8%   { opacity: 1; transform: translateX(0); }
   80%  { opacity: 1; transform: translateX(0); }
   100% { opacity: 0; transform: translateX(-2px); }
 }
@@ -161,6 +164,92 @@ a {
 
 .article-item.pulse {
   animation: article-pulse 2s ease-in-out 3;
+}
+
+/* ---- heading anchors (changelog and other sections) ---- */
+
+.changelog h2[id],
+.changelog h3[id],
+.changelog li[id],
+.section-title {
+  position: relative;
+}
+
+.heading-anchor {
+  position: absolute;
+  left: -1.15em;
+  top: 50%;
+  transform: translateY(-50%);
+  text-decoration: none;
+  font-size: 0.75em;
+  line-height: 1;
+  padding: 2px 4px;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  color: var(--bs-gray-500);
+}
+
+li[id] > .heading-anchor {
+  left: -2.8em;
+  top: 0.5em;
+  transform: none;
+}
+
+.section-title:hover .heading-anchor,
+h2[id]:hover .heading-anchor,
+h3[id]:hover .heading-anchor,
+li[id]:hover .heading-anchor,
+.heading-anchor:focus {
+  opacity: 0.7;
+}
+
+.heading-anchor:hover {
+  opacity: 1;
+  color: var(--bs-link-color);
+}
+
+@media (hover: none) {
+  .heading-anchor {
+    opacity: 0.7;
+  }
+  .heading-anchor:active {
+    opacity: 1;
+  }
+}
+
+.heading-anchor-toast {
+  position: absolute;
+  left: 100%;
+  top: 0;
+  white-space: nowrap;
+  background: #0d6efd;
+  color: #ffffff;
+  border: none;
+  border-radius: 4px;
+  padding: 1px 8px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  pointer-events: none;
+  animation: heading-anchor-toast-fade 1.5s ease forwards;
+}
+
+@keyframes heading-anchor-toast-fade {
+  0%   { opacity: 0; }
+  15%  { opacity: 1; }
+  80%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+@keyframes heading-pulse {
+  0%, 100% { background: transparent; }
+  50%      { background: var(--tf-articles-pulse-bg-color); }
+}
+
+.section-title.heading-pulse,
+h2[id].heading-pulse,
+h3[id].heading-pulse,
+li[id].heading-pulse {
+  animation: heading-pulse 2s ease-in-out 3;
 }
 
 .article-link {
@@ -183,6 +272,16 @@ a {
     background: var(--tf-articles-pulse-bg-color);
   }
   .article-share-toast {
+    animation: none;
+  }
+  .section-title.heading-pulse,
+  h2[id].heading-pulse,
+  h3[id].heading-pulse,
+  li[id].heading-pulse {
+    animation: none;
+    background: var(--tf-articles-pulse-bg-color);
+  }
+  .heading-anchor-toast {
     animation: none;
   }
 }

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -134,7 +134,7 @@ a {
   }
 }
 
-.article-share-toast {
+.copy-link-toast {
   position: absolute;
   left: 100%;
   top: 0;
@@ -147,23 +147,23 @@ a {
   font-size: 0.7rem;
   font-weight: 500;
   pointer-events: none;
-  animation: article-share-toast-fade 1.5s ease forwards;
+  animation: copy-link-toast-fade 1.5s ease forwards;
 }
 
-@keyframes article-share-toast-fade {
+@keyframes copy-link-toast-fade {
   0%   { opacity: 0; transform: translateX(4px); }
   8%   { opacity: 1; transform: translateX(0); }
   80%  { opacity: 1; transform: translateX(0); }
   100% { opacity: 0; transform: translateX(-2px); }
 }
 
-@keyframes article-pulse {
+@keyframes anchor-pulse {
   0%, 100% { background: transparent; }
   50%      { background: var(--tf-articles-pulse-bg-color); }
 }
 
-.article-item.pulse {
-  animation: article-pulse 2s ease-in-out 3;
+.article-item.anchor-pulse {
+  animation: anchor-pulse 2s ease-in-out 3;
 }
 
 /* ---- heading anchors (changelog and other sections) ---- */
@@ -217,39 +217,11 @@ li[id]:hover .heading-anchor,
   }
 }
 
-.heading-anchor-toast {
-  position: absolute;
-  left: 100%;
-  top: 0;
-  white-space: nowrap;
-  background: #0d6efd;
-  color: #ffffff;
-  border: none;
-  border-radius: 4px;
-  padding: 1px 8px;
-  font-size: 0.7rem;
-  font-weight: 500;
-  pointer-events: none;
-  animation: heading-anchor-toast-fade 1.5s ease forwards;
-}
-
-@keyframes heading-anchor-toast-fade {
-  0%   { opacity: 0; }
-  15%  { opacity: 1; }
-  80%  { opacity: 1; }
-  100% { opacity: 0; }
-}
-
-@keyframes heading-pulse {
-  0%, 100% { background: transparent; }
-  50%      { background: var(--tf-articles-pulse-bg-color); }
-}
-
-.section-title.heading-pulse,
-h2[id].heading-pulse,
-h3[id].heading-pulse,
-li[id].heading-pulse {
-  animation: heading-pulse 2s ease-in-out 3;
+.section-title.anchor-pulse,
+h2[id].anchor-pulse,
+h3[id].anchor-pulse,
+li[id].anchor-pulse {
+  animation: anchor-pulse 2s ease-in-out 3;
 }
 
 .article-link {
@@ -267,21 +239,18 @@ li[id].heading-pulse {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .article-item.pulse {
+  .article-item.anchor-pulse {
     animation: none;
     background: var(--tf-articles-pulse-bg-color);
   }
-  .article-share-toast {
+  .copy-link-toast {
     animation: none;
   }
-  .section-title.heading-pulse,
-  h2[id].heading-pulse,
-  h3[id].heading-pulse,
-  li[id].heading-pulse {
+  .section-title.anchor-pulse,
+  h2[id].anchor-pulse,
+  h3[id].anchor-pulse,
+  li[id].anchor-pulse {
     animation: none;
     background: var(--tf-articles-pulse-bg-color);
-  }
-  .heading-anchor-toast {
-    animation: none;
   }
 }


### PR DESCRIPTION
## Summary

Section titles and changelog headings now show a copyable anchor link on hover, same as GitHub does on markdown files. Click copies a direct URL; share it and the recipient lands on the exact heading with a pulse highlight. I also fixed a few things in the article share button while I was in here — toast no longer shoves text around, the icon doesn't linger after copying, and the scroll-spy stops clobbering changelog hashes on page load.

## Changes

- 29 changelog headings (h2 and h3) and 4 section titles got `<a>` anchor tags rendered server-side by Jekyll, so they're in the DOM from the start
- Any `<li>` with a `changelog-*` id gets an anchor injected by JS on load — covers existing items and anything added later, no template edits needed
- Anchor icons hidden until hover, absolute-positioned so they never shift text, pushed left of the bullet on list items
- Toast background is solid blue now — was translucent because the parent button's CSS `opacity` multiplied into the toast. Parent gets forced to `opacity: 1` while the toast is visible
- `.blur()` after copy so the icon disappears instead of holding `:focus` opacity
- Scroll-spy suppresses its first update for 500ms and refuses to overwrite `#changelog-` hashes (same guard it already had for `#article-`)
- Pulse highlight on hash navigation works for h2, h3, and li — not just h3

## Test Plan

- [x] Generated HTML has all 29 changelog heading anchors, 4 section anchors, correct hrefs
- [x] Hover reveals icon, click copies full URL to clipboard, toast shows solid and fades out, icon disappears
- [x] Direct links to `#changelog-*` IDs survive page load without the scroll-spy replacing them
- [x] Touch devices show anchor icon at partial opacity without hover
- [x] `prefers-reduced-motion` disables pulse and toast animations

## Related

Closes https://github.com/couimet/couimet.github.io/issues/41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added copy-link icons (🔗) to section headings and article/project/career entries, with a centralized copy behavior and transient toast feedback.
  * Anchor pulse animation highlights targeted sections when navigating via hashes.

* **Enhancements**
  * Improved URL-hash handling to avoid clobbering subsection hashes on navigation.
  * Accessibility: aria-labels for copy links and live-region toast announcements; reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->