### PR TITLE
# [issues/42] Automate deployment to ouimet.info on push to main

### DIFF
--- a/.github/workflows/deploy-ouimet-info.yml
+++ b/.github/workflows/deploy-ouimet-info.yml
@@ -1,60 +1,34 @@
-# Option B: manually triggered deploy — credentials typed at trigger time, never stored.
+# Deploy to ouimet.info on every push to main via SSH keypair auth.
+# SSH keypairs are the best practice for CI/CD: no password to brute-force, easy to revoke,
+# and the private key never leaves GitHub Secrets.
 #
-# Migrating to Option C (automated on every push to main, SSH keypair auth):
-#   SSH keypairs are the best practice for CI/CD: no password to brute-force, easy to revoke,
-#   and the private key never leaves GitHub Secrets.
+# Server setup (run locally on any machine, then SSH into the server):
+#   ssh-keygen -t ed25519 -C "github-deploy-ouimet.info" -f ~/.ssh/ouimet_deploy
+#   ssh-copy-id -i ~/.ssh/ouimet_deploy.pub <your-ssh-user>@<your-ssh-host>
+#   cat ~/.ssh/ouimet_deploy   # copy this — it's the private key to paste into GitHub
 #
-#   One-time server setup (run locally, then SSH into the server):
-#     ssh-keygen -t ed25519 -C "github-deploy-ouimet.info" -f ~/.ssh/ouimet_deploy
-#     ssh-copy-id -i ~/.ssh/ouimet_deploy.pub <your-ssh-user>@<your-ssh-host>
-#     cat ~/.ssh/ouimet_deploy   # copy this — it's the private key to paste into GitHub
+# Get the host fingerprint (run locally, no authentication needed):
+#   ssh-keyscan -t ed25519 <your-ssh-host> | ssh-keygen -lf - -E sha256
+#   Copy the SHA256:... portion (including the SHA256: prefix) without the host name.
 #
-#   Get the host fingerprint (run locally, no authentication needed):
-#     ssh-keyscan -t ed25519 <your-ssh-host> | ssh-keygen -lf - -E sha256
-#     Copy the SHA256:... portion (including the SHA256: prefix).
-#
-#   1. In GitHub → Settings → Secrets and variables → Actions, create these secrets:
-#        OUIMET_INFO_SSH_HOST          the SSH hostname your provider gave you
-#        OUIMET_INFO_SSH_USERNAME      your SSH login (same username you use in terminal)
-#        OUIMET_INFO_SSH_PRIVATE_KEY   paste the private key generated above (entire file content)
-#        OUIMET_INFO_REMOTE_PATH       ~/ouimet_info
-#        OUIMET_INFO_SSH_FINGERPRINT   the SHA256:... value from ssh-keyscan above
-#   2. Replace the `on:` block below with:
-#        on:
-#          push:
-#            branches: ["main"]
-#          workflow_dispatch:
-#   3. Apply the inline # Option C substitutions shown on each credential line below.
-#      Note: `password:` becomes `key:` — it is a different field name, not just a value swap.
-#   4. Delete the "Mask password" step — secrets are masked automatically.
-name: Deploy to ouimet.info (manual)
+# Required repository secrets (Settings → Secrets and variables → Actions → Repository secrets):
+#   OUIMET_INFO_SSH_HOST          the SSH hostname your provider gave you
+#   OUIMET_INFO_SSH_USERNAME      your SSH login
+#   OUIMET_INFO_SSH_PRIVATE_KEY   SSH ed25519 private key
+#   OUIMET_INFO_REMOTE_PATH       ~/ouimet_info
+#   OUIMET_INFO_BACKUP_DIR        ~/ouimet_info_backups
+#   OUIMET_INFO_SSH_FINGERPRINT   SHA256:... host key fingerprint
+name: Deploy to ouimet.info
 
 on:
+  push:
+    branches: ["main"]
   workflow_dispatch:
-    inputs:
-      host:
-        description: 'SSH host (e.g. ssh.your-provider.com)'
-        required: true
-      username:
-        description: 'SSH username'
-        required: true
-      password:
-        description: 'SSH password (masked in logs)'
-        required: true
-      remote_path:
-        description: 'Remote web root path'
-        required: true
-        default: '~/ouimet_info'
-      fingerprint:
-        description: 'SHA256 fingerprint of server host key — get it with: ssh-keyscan -t ed25519 <host> | ssh-keygen -lf - -E sha256'
-        required: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Mask password  # Remove this step in Option C — secrets are masked automatically
-        run: echo "::add-mask::${{ inputs.password }}"
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
@@ -73,17 +47,17 @@ jobs:
       - name: Backup existing site on server
         uses: appleboy/ssh-action@v1.2.5
         with:
-          host: ${{ inputs.host }}                  # Option C: ${{ secrets.OUIMET_INFO_SSH_HOST }}
-          username: ${{ inputs.username }}           # Option C: ${{ secrets.OUIMET_INFO_SSH_USERNAME }}
-          password: ${{ inputs.password }}           # Option C: key: ${{ secrets.OUIMET_INFO_SSH_PRIVATE_KEY }}  ← field name changes from 'password' to 'key'
-          fingerprint: ${{ inputs.fingerprint }}     # Option C: ${{ secrets.OUIMET_INFO_SSH_FINGERPRINT }}
+          host: ${{ secrets.OUIMET_INFO_SSH_HOST }}
+          username: ${{ secrets.OUIMET_INFO_SSH_USERNAME }}
+          key: ${{ secrets.OUIMET_INFO_SSH_PRIVATE_KEY }}
+          fingerprint: ${{ secrets.OUIMET_INFO_SSH_FINGERPRINT }}
           script: |
-            BACKUP_DIR="$HOME/ouimet_info_backups"
+            BACKUP_DIR="${{ secrets.OUIMET_INFO_BACKUP_DIR }}"
             BACKUP_FILE="$BACKUP_DIR/$(date +%Y%m%d-%H%M%S).tar.gz"
-            BACKUP_PARENT="$(dirname "${{ inputs.remote_path }}")"
-            BACKUP_NAME="$(basename "${{ inputs.remote_path }}")"
+            BACKUP_PARENT="$(dirname "${{ secrets.OUIMET_INFO_REMOTE_PATH }}")"
+            BACKUP_NAME="$(basename "${{ secrets.OUIMET_INFO_REMOTE_PATH }}")"
             mkdir -p "$BACKUP_DIR"
-            if [[ -d "${{ inputs.remote_path }}" ]]; then
+            if [[ -d "${{ secrets.OUIMET_INFO_REMOTE_PATH }}" ]]; then
               tar -czf "$BACKUP_FILE" -C "$BACKUP_PARENT" "$BACKUP_NAME"
               echo "Backup created at $BACKUP_FILE"
             else
@@ -95,10 +69,10 @@ jobs:
       - name: Upload built site
         uses: appleboy/scp-action@v1.0.0
         with:
-          host: ${{ inputs.host }}                  # Option C: ${{ secrets.OUIMET_INFO_SSH_HOST }}
-          username: ${{ inputs.username }}           # Option C: ${{ secrets.OUIMET_INFO_SSH_USERNAME }}
-          password: ${{ inputs.password }}           # Option C: key: ${{ secrets.OUIMET_INFO_SSH_PRIVATE_KEY }}  ← field name changes from 'password' to 'key'
-          fingerprint: ${{ inputs.fingerprint }}     # Option C: ${{ secrets.OUIMET_INFO_SSH_FINGERPRINT }}
+          host: ${{ secrets.OUIMET_INFO_SSH_HOST }}
+          username: ${{ secrets.OUIMET_INFO_SSH_USERNAME }}
+          key: ${{ secrets.OUIMET_INFO_SSH_PRIVATE_KEY }}
+          fingerprint: ${{ secrets.OUIMET_INFO_SSH_FINGERPRINT }}
           source: '_site/*'
-          target: ${{ inputs.remote_path }}         # Option C: ${{ secrets.OUIMET_INFO_REMOTE_PATH }}
+          target: ${{ secrets.OUIMET_INFO_REMOTE_PATH }}
           strip_components: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # required to publish the site.zip GitHub Release used by sync-ouimet-info.sh
       pages: write
       id-token: write
     steps:
@@ -51,20 +50,6 @@ jobs:
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Package _site as zip for ouimet.info sync
-        # zip from inside _site so paths are root-relative (not _site/foo) when extracted
-        run: cd _site && zip -r ../site.zip .
-      - name: Publish site.zip as GitHub Release
-        # Overwrites the 'latest' release on every push so the download URL stays stable:
-        # https://github.com/couimet/couimet.github.io/releases/latest/download/site.zip
-        # Pinned to commit SHA for supply-chain safety (v2 = 3bb12739...)
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
-        with:
-          tag_name: latest
-          name: Latest site build
-          body: "Auto-published on every push to main. Used by scripts/sync-ouimet-info.sh to sync ouimet.info."
-          files: site.zip
-          make_latest: true
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -19,3 +19,9 @@ Run the server:
 ```bash
 bundle exec jekyll serve
 ```
+
+## Deployment
+
+Pushes to `main` are automatically deployed to ouimet.info via `.github/workflows/deploy-ouimet-info.yml` (SSH keypair auth). See the workflow file header for required repository secrets.
+
+The `scripts/sync-ouimet-info.sh` script is kept as a manual recovery tool for rollbacks and direct-from-release syncs.

--- a/scripts/sync-ouimet-info.sh
+++ b/scripts/sync-ouimet-info.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Run this script ON your server after SSH-ing in.
+# Superseded by the automated GitHub Actions deploy workflow (.github/workflows/deploy-ouimet-info.yml)
+# for normal operation. Kept as a manual recovery tool — run this ON your server after SSH-ing in
+# if you need to roll back or sync from GitHub Releases directly.
 # It downloads the latest site.zip from the GitHub Release for this repo and
 # syncs it into the ouimet.info web root, creating a compressed backup first.
 # Requires: wget, unzip, rsync (all confirmed available on the server).


### PR DESCRIPTION
## Summary

Migrates the ouimet.info deployment from a manual SSH pull-based workflow to an automated push-based workflow using SSH keypair auth. Pushes to `main` now trigger a Jekyll build and deploy directly to the hosting server. The manual sync script stays as a rollback/recovery tool.

## Changes

- **deploy-ouimet-info.yml** — converted from Option B (manual trigger, password auth) to Option C (push to main, SSH keypair). Removed `workflow_dispatch` inputs, "Mask password" step, and all `inputs.*` references in favor of `secrets.*`. Changed `password:` to `key:` on both SSH steps.
- **deploy-ouimet-info.yml** — added `OUIMET_INFO_BACKUP_DIR` secret to parameterize backup directory path
- **main.yml** — removed site.zip packaging and GitHub Release publishing steps (dead weight now that deploy pushes directly)
- **main.yml** — dropped `contents: write` permission (was only needed for the release step)
- **sync-ouimet-info.sh** — updated header to note it's superseded but kept for manual recovery
- **README.md** — added `Deployment` section documenting automated deploy

## Test Plan

- [ ] No test suite in this project
- [ ] Manual: workflow_dispatch trigger after merge to verify end-to-end
- [x] SSH keypair installed on hosting server
- [x] 6 repository secrets configured on GitHub
- [x] Workflow YAML syntax valid

Closes https://github.com/couimet/couimet.github.io/issues/42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now automatically triggers on pushes to the main branch
  * Enhanced deployment authentication for improved security
  * Removed automated release archive publication

* **Documentation**
  * Added deployment section to README with recovery instructions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/46)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->