### PR TITLE
# [issues/48] Match changelog page title behavior with other sections

### DIFF
--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -3,8 +3,14 @@
     <div class="row mb-3">
       <div class="col-md-6">
         <h1 class="display-4 text-start section-title">
-          <a href="#career-changelog" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
-          <a class="text-reset" href="{{ '/career/changelog/' | prepend: site.baseurl }}">Career Changelog</a>
+          {% if page.url == '/' %}
+            <a href="#career-changelog" class="heading-anchor" aria-label="Copy link to this section">🔗</a>
+          {% endif %}
+          {% if page.url == '/career/changelog/' %}
+            Career Changelog
+          {% else %}
+            <a class="text-reset" href="{{ '/career/changelog/' | prepend: site.baseurl }}">Career Changelog</a>
+          {% endif %}
         </h1>
       </div>
     </div>


### PR DESCRIPTION
## Summary

PR #43 added hover anchor links to section titles, but the changelog's H1 was inconsistent with the other three sections in two ways:
1. The `🔗` anchor rendered unconditionally (others guard with `{% if page.url == '/' %}`)
2. The title was always a clickable link, even on the dedicated page — a self-referencing link

Both are now fixed with the same `{% if %}` pattern used by projects, articles, and follow-alongs.

## Changes

- **_includes/career/changelog.html** — wrapped `🔗` anchor in `{% if page.url == '/' %}` so it only shows on the homepage; made the title plain text on `/career/changelog/` instead of a self-referencing link, matching the other three sections

Closes https://github.com/couimet/couimet.github.io/issues/48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Career Changelog page header behavior. The "copy link" icon now displays conditionally based on page context, and the "Career Changelog" text adapts to show either as a plain text label or a clickable link depending on the current page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/49)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->