### PR TITLE
[issues/44] Make anchor links discoverable and tappable on mobile

### DIFF
--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -209,11 +209,34 @@ li[id]:hover .heading-anchor,
 }
 
 @media (hover: none) {
-  .heading-anchor {
-    opacity: 0.7;
+  .heading-anchor,
+  li[id] > .heading-anchor {
+    position: relative;
+    display: inline-block;
+    top: auto;
+    left: auto;
+    transform: none;
+    opacity: 0.85;
+    padding: 0.25rem 0.4rem;
+    margin-right: 0.25rem;
+  }
+  .section-title:has(> .heading-anchor),
+  h2[id]:has(> .heading-anchor),
+  h3[id]:has(> .heading-anchor) {
+    display: flex;
+    align-items: first baseline;
+    column-gap: 0.25rem;
+  }
+  .section-title > .heading-anchor,
+  h2[id] > .heading-anchor,
+  h3[id] > .heading-anchor {
+    font-size: 1rem;
+    margin-right: 0;
+    flex-shrink: 0;
   }
   .heading-anchor:active {
     opacity: 1;
+    color: var(--bs-link-color);
   }
 }
 


### PR DESCRIPTION
## Summary

Reworks the `@media (hover: none)` styling for `.heading-anchor` so the 🔗 icons that sit next to section titles, changelog headings, and changelog list items are clearly visible, comfortably tappable, and properly laid out on touch devices. Desktop hover-reveal behavior is untouched.

## Changes

- Switched touch-device anchor layout from absolute positioning to in-flow: anchors now sit inline before the heading text (and inline at the start of `li[id]` items), eliminating off-screen clipping at narrow viewports
- Neutralized inherited `left`/`top` offsets from the base absolute-positioned rules so they don't leak into the `position: relative` touch layout (this was the root cause of the apparent "huge gap" and bullet/icon overlap in earlier iterations)
- Headings (`.section-title`, `h2[id]`, `h3[id]`) become flex containers on touch using `:has(> .heading-anchor)`, so spacing between icon and heading text is a precise `column-gap` rather than a fight against emoji glyph bearings
- Heading anchors render at a fixed `font-size: 1rem` on touch so the icon doesn't scale up with `display-4` headings and dominate visually
- Vertical alignment uses `align-items: first baseline` so the icon sits next to the first line of multi-line headings (e.g. `8.0.0 - Staff Software Developer @ Shopify (2025 to 2026)`), matching the way list-item anchors sit next to their first line
- Bumped touch opacity from `0.7` to `0.85` and added a generous tap-target via `padding: 0.25rem 0.4rem`
- Documentation: CHANGELOG not needed — project has no CHANGELOG file. README not needed — this is a cosmetic CSS change in a Jekyll theme file with no user-facing settings or commands to document.

## Key Discoveries

- The original absolute-positioning approach couldn't escape a trilemma on mobile: anchored far left → clips off the viewport edge; anchored close → overlaps heading text; padded heading → unnatural gap. The captured analysis is in `notes/20260510-172130-mobile-anchor-inline-flow-proposal.txt`.
- The hidden bug behind several "still too much space" iterations was that `position: relative` (set inside the touch media query) was still inheriting `left: -1.15em` / `left: -2.8em` from the base absolute rules, visually shifting the icon out of its flex position while the flex container reserved the unshifted slot for layout. Explicit `left: auto; top: auto` overrides resolved this.
- Apple Color Emoji `🔗` carries significant intrinsic side-bearing whitespace. Inline-flow spacing scales that whitespace with the parent font size, so `em`-based margins compounded badly on `display-4` headings. Flexbox `column-gap` sidesteps glyph metrics entirely.

## Test Plan

- [ ] iPhone-class viewport (375px) in Chrome DevTools device mode: anchor icons visible at 85% opacity, no clipping off the left edge on any heading or list item
- [ ] Homepage `/`: anchor icons sit next to `Projects`, `Articles`, `Follow-alongs` titles with tight spacing; tap copies the URL and toast appears without forcing horizontal scroll
- [ ] `/career/changelog/`: h2/h3 anchors sit next to the first line of multi-line headings (e.g. `8.0.0 - Staff Software Developer...`); changelog `<li>` anchors visible alongside bullets
- [ ] Desktop hover behavior unchanged: anchors hidden at `opacity: 0` until hover, then revealed

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/44
- Builds on https://github.com/couimet/couimet.github.io/pull/43 (issues/41 — initial hover anchor implementation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved heading anchor link styling on touch devices with enhanced layout, spacing, and visual presentation.
  * Added visual feedback for heading link activation on non-hover devices with updated color styling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/50)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->