### PR TITLE
Publish DeepSeek + Claude Code article

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ exclude:
   - LICENSE
   - README.md
   - .history
+  - articles/_sources
 include:
   - .nojekyll
   - _data

--- a/_data/articles.json
+++ b/_data/articles.json
@@ -1,5 +1,11 @@
 [
   {
+    "date": "2026-05-12",
+    "title": "Eight env vars and Claude Code stops eating my paycheck",
+    "link": "https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659",
+    "anchor": "deepseek-claude-code"
+  },
+  {
     "date": "2026-04-21",
     "title": "I thought I was DRY-ing. I may have been double-paying.",
     "link": "https://dev.to/couimet/i-thought-i-was-dry-ing-i-may-have-been-double-paying-5dli",

--- a/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
+++ b/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
@@ -1,0 +1,65 @@
+# Eight env vars and Claude Code stops eating my paycheck
+
+DeepSeek's quick-start page has been live for months. I'm late to it.
+
+I love what Anthropic ships. Opus 4.7 is the best coding model I've used. I also can't run it all day on a family budget, and Pro's 5-hour quota wall stopped my flow more times than I want to count. So a few days ago I exported eight env vars, pointed Claude Code at DeepSeek, and went back to building [rangeLink](https://ouimet.info/projects/rangelink-extension.html). Since then I've only spent $4 and haven't seen a rate limit.
+
+## The eight env vars
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
+export ANTHROPIC_AUTH_TOKEN=<your-deepseek-key>
+export ANTHROPIC_MODEL=deepseek-v4-pro
+export ANTHROPIC_DEFAULT_OPUS_MODEL=deepseek-v4-pro
+export ANTHROPIC_DEFAULT_SONNET_MODEL=deepseek-v4-pro
+export ANTHROPIC_DEFAULT_HAIKU_MODEL=deepseek-v4-flash
+export CLAUDE_CODE_SUBAGENT_MODEL=deepseek-v4-flash
+export CLAUDE_CODE_EFFORT_LEVEL=max
+```
+
+Run that block in your terminal, then invoke `claude-code`.
+
+## What's going on in there
+
+The subagent model points to `deepseek-v4-flash` instead of `v4-pro`. Claude Code spawns subagents for grep-and-summarize work, and there's no reason to pay pro rates for "find the file that has this string." Flash is good enough for that, and it returns faster.
+
+`CLAUDE_CODE_EFFORT_LEVEL=max` keeps the quality slider cranked on the cheap path. The flag exists; you may as well use it.
+
+Anthropic's three tiers (Opus, Sonnet, Haiku) get collapsed onto DeepSeek's two. Opus and Sonnet both map to `v4-pro` because that's the strongest model DeepSeek serves. Haiku goes to `v4-flash` because nothing about Haiku-class work needs more than that.
+
+## Why I'm still using this a week later
+
+**Cost.** I bought $10 of `deepseek-v4-pro` credits last week. After five days of 3-6 hours a day on rangeLink, $6 is still on the meter. I stopped checking the balance after day three because it wasn't going anywhere fast.
+
+**No 5-hour quota wall.** Anthropic Pro's quota window resets on a 5-hour cycle, and hitting it mid-task is the worst kind of interruption. You've built up context, you're in the middle of something, and now you're either waiting or paying for top-up. Since I switched: zero waits. Not "fewer." Zero.
+
+The second one matters more than I expected. Going in, I was solving for cost. I figured rate limits were a nice-to-have.
+
+## The catch I hit
+
+Pasted images in the terminal don't make it through to DeepSeek's API. If your workflow leans on screenshots — "look at this dev-tools error" or "match this design" — this swap will hurt.
+
+Community work is happening here. I'm not going to recommend anything I haven't fully tested.
+
+## Same trick, different provider
+
+A friend was already running DeepSeek with [OpenClaw](https://docs.openclaw.ai/) and happy with it, so I copied his pick when I made the switch. Two worth a look as of May 2026:
+
+- **Moonshot Kimi K2.5** — `ANTHROPIC_BASE_URL=https://api.moonshot.ai/anthropic`, model `kimi-k2.5`. [Moonshot's Claude Code setup docs](https://platform.kimi.ai/docs/guide/agent-support).
+- **Z.ai GLM-5.1** — `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`, model `glm-5.1`. [Z.AI Claude Code docs](https://docs.z.ai/devpack/tool/claude).
+
+If you've run Kimi or GLM with Claude Code, I'd be curious how it went.
+
+## A note on privacy
+
+Your prompts go to DeepSeek's servers. Fine for my public-repo work. Pick a provider whose data policy matches your repos' sensitivity.
+
+---
+
+Five days, $4 spent, zero rate-limit walls.
+
+If your employer foots the Anthropic bill, or your wallet can swing a Max plan, by all means — Opus 4.7 is still the best at the top end. If that's not you, eight env vars.
+
+```
+Co-Authored-By: Claude <noreply@anthropic.com> (running on deepseek-v4-pro)
+```

--- a/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
+++ b/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
@@ -60,6 +60,5 @@ Five days, $4 spent, zero rate-limit walls.
 
 If your employer foots the Anthropic bill, or your wallet can swing a Max plan, by all means — Opus 4.7 is still the best at the top end. If that's not you, eight env vars.
 
-```
+```text
 Co-Authored-By: Claude <noreply@anthropic.com> (running on deepseek-v4-pro)
-```


### PR DESCRIPTION
## Summary

Publishes a new dev.to article ("Eight env vars and Claude Code stops eating my paycheck") and wires up the repo to keep the markdown source local without exposing it on the published site. Adds the dev.to URL to the site's article index so it shows up alongside prior posts.

## Changes

- Add new article source at `articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md`
- Add `articles/_sources` to Jekyll's `exclude:` list in `_config.yml` so markdown sources stay local without being served by the site.
- Append the published dev.to URL to `_data/articles.json` (date `2026-05-12`, anchor `deepseek-claude-code`).

## Test Plan

- [x] Article renders correctly on dev.to (verified at the published URL)
- [x] Markdown source visible in repo, not in `_site/` (Jekyll exclude works)
- [ ] After merge: confirm the article appears on the site's articles index page

## Related

- Published article: https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new article on running Claude Code with DeepSeek: environment-variable setup, model selection and cost tips, provider/model alternatives, a privacy note, and a known limitation with terminal-pasted images.
* **Chores**
  * Updated site build configuration to exclude a sources directory from processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->