### PR TITLE
[issues/54] Sequence GitHub Actions on push to main

### DIFF
--- a/.github/workflows/deploy-ouimet-info.yml
+++ b/.github/workflows/deploy-ouimet-info.yml
@@ -1,4 +1,4 @@
-# Deploy to ouimet.info on every push to main via SSH keypair auth.
+# Deploy to ouimet.info after a successful GitHub Pages deploy, via SSH keypair auth.
 # SSH keypairs are the best practice for CI/CD: no password to brute-force, easy to revoke,
 # and the private key never leaves GitHub Secrets.
 #
@@ -26,17 +26,25 @@
 name: Deploy to ouimet.info
 
 on:
-  push:
-    branches: ["main"]
+  # Chained after the GitHub Pages deploy so both targets stay in lockstep on the freshest tree
+  workflow_run:
+    workflows: ["Deploy Jekyll site to Pages"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Skip when the upstream Pages deploy failed; always run on manual dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # workflow_run defaults to the upstream's head_sha; pin to main to include sync auto-commits
+          ref: main
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,14 @@
 # documentation.
 
 # Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll site to Pages 2
+name: Deploy Jekyll site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
+  # Chained after Sync JSON → YAML Resume so we deploy the freshest resume-full.html
+  workflow_run:
+    workflows: ["Sync JSON → YAML Resume"]
+    types: [completed]
+    branches: [main]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -30,12 +32,18 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # Skip when the upstream Sync workflow failed; always run on manual dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       pages: write
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # workflow_run defaults to the upstream's head_sha, which predates the sync auto-commit;
+          # pin to main so we build with the freshest resume-full.html
+          ref: main
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -61,6 +69,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/sync-resume.yml
+++ b/.github/workflows/sync-resume.yml
@@ -3,8 +3,6 @@ name: Sync JSON → YAML Resume
 on:
   push:
     branches: ["main"]
-    paths:
-      - resume.json
   workflow_dispatch:
 
 permissions:
@@ -25,5 +23,5 @@ jobs:
           git config user.email "actions@github.com"
           git pull --rebase origin main
           git add -f resume.yml resume-full.html
-          git commit -m "chore: sync YAML resume and HTML" || echo "No changes"
+          git commit -m "chore: sync YAML resume and HTML [skip ci]" || echo "No changes"
           git push


### PR DESCRIPTION
## Summary

The three workflows that fire on push to `main` (`Sync JSON → YAML Resume`, `Deploy Jekyll site to Pages`, `Deploy to ouimet.info`) ran in parallel, so both deploys built before sync had regenerated and committed `resume-full.html` — deployed sites were a cycle behind. This change chains them as a pipeline via `workflow_run` so each step only runs after the previous succeeds, and renames the Pages workflow to drop the stale ` 2` suffix.

## Changes

- `sync-resume.yml`: removed the `paths: [resume.json]` filter so the workflow runs on every push to `main` (it's the head of the chain — required to be unconditional); appended `[skip ci]` to the auto-commit message so the regenerated `resume.yml` / `resume-full.html` push doesn't re-trigger the pipeline
- `main.yml`: renamed `Deploy Jekyll site to Pages 2` → `Deploy Jekyll site to Pages`; replaced `push: branches: [main]` trigger with `workflow_run` chained off `Sync JSON → YAML Resume` (completed, branches: main); added `if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'` to both the `build` and `deploy` jobs so manual dispatch still works and failed upstream runs short-circuit; pinned the checkout step to `ref: main` so the build picks up sync-resume's auto-commit (workflow_run defaults to the upstream's `head_sha`, which predates the auto-commit)
- `deploy-ouimet-info.yml`: same trigger swap (chained off `Deploy Jekyll site to Pages`), same `if:` guard on the deploy job, same `ref: main` pin on checkout; refreshed the stale top-of-file comment that said "every push to main"

## Test Plan

- [ ] After merge, push a trivial commit to `main` and watch the Actions tab confirm the pipeline order: Sync → Pages → ouimet.info, with each step gated on the previous success
- [ ] Confirm `workflow_dispatch` still works standalone on each of the three workflows (manual runs should bypass the `if:` success check)
- [ ] After a `resume.json` change, confirm sync's auto-commit no longer re-triggers the pipeline (the `[skip ci]` marker takes effect) and that the deployed sites reflect the regenerated `resume-full.html`
- [ ] Confirm a failure in sync prevents Pages from running, and a failure in Pages prevents ouimet.info from running

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment now waits for the site/content sync to finish before running the site publish step, while still allowing manual deploys.
  * Build and deploy use a consistent commit reference so the latest synced content is included.
  * Automated resume commits now include a marker to skip CI when appropriate.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/56)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->