### PR TITLE
[issues/57] Publish `scratchpad-to-note` article

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Repo conventions for Claude
+
+## Article sources (`articles/_sources/`)
+
+`articles/_sources/` is only for articles that were drafted **in this repo**. If an article was authored in a different repo (where it has its richer context, diagrams, history, and review), do **not** copy or mirror the markdown source here. Just add the published URL to `_data/articles.json`.
+
+The site links out to the canonical published URL either way, so mirroring an externally-authored source here only creates a stale duplicate.

--- a/_data/articles.json
+++ b/_data/articles.json
@@ -1,5 +1,11 @@
 [
   {
+    "date": "2026-05-21",
+    "title": "I sold you on /scratchpad. Then I migrated to /note.",
+    "link": "https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o",
+    "anchor": "scratchpad-to-note"
+  },
+  {
     "date": "2026-05-12",
     "title": "Eight env vars and Claude Code stops eating my paycheck",
     "link": "https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659",


### PR DESCRIPTION
## Summary

Surfaces the third dev.to post ("I sold you on /scratchpad. Then I migrated to /note.") on the site's article index. The article was authored in `couimet/my-claude-skills` (PR 140), so only the published URL is added here. Also adds `CLAUDE.md` to capture the rule that `articles/_sources/` is for in-repo drafts only.

## Changes

- Prepend a new entry to `_data/articles.json` with date `2026-05-21`, anchor `scratchpad-to-note`, and the published dev.to URL.
- Add `CLAUDE.md` documenting that externally-authored articles must not be mirrored into `articles/_sources/`.

## Test Plan

- [x] Article renders on dev.to (verified at the published URL).
- [x] `_data/articles.json` validates as JSON.
- [ ] After merge: confirm the entry appears at the top of `/articles/` on ouimet.info and the anchor `#article-scratchpad-to-note` scrolls to the right card.

## Related

- Source article repo: https://github.com/couimet/my-claude-skills/pull/140
- Published article: https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o
- Closes https://github.com/couimet/couimet.github.io/issues/57