### PR TITLE
[issues/60] Show related articles on each project page

### DIFF
--- a/_data/articles.json
+++ b/_data/articles.json
@@ -3,7 +3,8 @@
     "date": "2026-05-21",
     "title": "I sold you on /scratchpad. Then I migrated to /note.",
     "link": "https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o",
-    "anchor": "scratchpad-to-note"
+    "anchor": "scratchpad-to-note",
+    "projects": ["my-claude-skills"]
   },
   {
     "date": "2026-05-12",
@@ -15,30 +16,35 @@
     "date": "2026-04-21",
     "title": "I thought I was DRY-ing. I may have been double-paying.",
     "link": "https://dev.to/couimet/i-thought-i-was-dry-ing-i-may-have-been-double-paying-5dli",
-    "anchor": "dry-ing-double-paying"
+    "anchor": "dry-ing-double-paying",
+    "projects": ["my-claude-skills"]
   },
   {
     "date": "2026-03-16",
     "title": "From Vide Coding to Supercharged Vibe Guiding",
     "link": "https://dev.to/couimet/from-vide-coding-to-supercharged-vibe-guiding-6nm",
-    "anchor": "vibe-guiding"
+    "anchor": "vibe-guiding",
+    "projects": ["my-claude-skills"]
   },
   {
     "date": "2025-12-16",
     "title": "RangeLink v1.0.0: Perfected AI Workflows + The R-Keybinding Family",
     "link": "https://dev.to/couimet/rangelink-v100-perfected-ai-workflows-the-r-keybinding-family-104b",
-    "anchor": "rangelink-v1"
+    "anchor": "rangelink-v1",
+    "projects": ["rangelink-extension"]
   },
   {
     "date": "2025-11-12",
     "title": "RangeLink v0.3.0: One Keybinding to Rule Them All",
     "link": "https://dev.to/couimet/rangelink-v030-one-keybinding-to-rule-them-all-2h01",
-    "anchor": "rangelink-v03"
+    "anchor": "rangelink-v03",
+    "projects": ["rangelink-extension"]
   },
   {
     "date": "2025-11-08",
     "title": "I Built a VS Code Extension to Stop the Copy-Paste Madness",
     "link": "https://dev.to/couimet/i-built-a-vs-code-extension-to-stop-the-copy-paste-madness-3d7l",
-    "anchor": "copy-paste-madness"
+    "anchor": "copy-paste-madness",
+    "projects": ["rangelink-extension"]
   }
 ]

--- a/_includes/projects/project-articles.html
+++ b/_includes/projects/project-articles.html
@@ -1,0 +1,39 @@
+{% assign project_slug = page.slug | default: page.path | split: '/' | last | replace: '.md', '' %}
+{% assign related = "" | split: "" %}
+{% for article in site.data.articles %}
+  {% if article.projects %}
+    {% if article.projects contains project_slug %}
+      {% assign related = related | push: article %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+
+{% if related.size > 0 %}
+  {% assign related = related | sort: "date" | reverse %}
+  {% assign utm_campaign = "project-" | append: project_slug %}
+  <div class="mt-5">
+    <h2 class="h4 mb-3">Articles about this project</h2>
+    <div class="articles-scroll">
+      {% for article in related %}
+        {% assign link_base = article.link | split: '#' | first %}
+        {% assign link_fragment = article.link | remove_first: link_base %}
+        {% assign utm_separator = '?' %}
+        {% if link_base contains '?' %}
+          {% assign utm_separator = '&' %}
+        {% endif %}
+        {% capture article_href %}{{ link_base }}{{ utm_separator }}utm_source=ouimet.info&utm_medium=referral&utm_campaign={{ utm_campaign | url_encode }}{{ link_fragment }}{% endcapture %}
+        <article class="article-item px-3 py-2">
+          <p class="article-date mb-1">{{ article.date }}</p>
+          <a
+            class="article-link"
+            href="{{ article_href }}"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ article.title }}
+          </a>
+        </article>
+      {% endfor %}
+    </div>
+  </div>
+{% endif %}

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -36,6 +36,8 @@ layout: home
   <div class="mt-3">
     {{ content }}
   </div>
+
+  {% include projects/project-articles.html %}
 </div>
 
 <p class="text-center pt-4"><a href="{{ site.baseurl}}/projects/">See all projects</a></p>


### PR DESCRIPTION
## Summary

Each project page now renders a "Articles about this project" section listing the articles tied to that project, pulled from `_data/articles.json`. Closes the gap surfaced in #59 where ouimet.info/projects/my-claude-skills.html read as out-of-date even when the article feed was fresh.

## Changes

- Added an optional `projects` array to article entries in `_data/articles.json`. Six existing articles tagged: three to `my-claude-skills` (`scratchpad-to-note`, `dry-ing-double-paying`, `vibe-guiding`), three to `rangelink-extension` (`rangelink-v1`, `rangelink-v03`, `copy-paste-madness`). `deepseek-claude-code` left untagged: it covers Claude Code cost optimization, not a specific project.
- New `_includes/projects/project-articles.html` partial. Filters `site.data.articles` by `page.slug` (with `page.path` fallback because Jekyll's auto-slug is empty for non-collection pages), sorts newest-first, renders a compact list styled to match the existing `article-item` look. Outlinks carry `utm_campaign=project-<slug>`. Renders nothing when no related articles exist.
- `_layouts/project.html` includes the partial after the project body.
- Documentation: CHANGELOG not needed (no site-level changelog). README not needed (mechanism is self-documenting via the `projects` field; future tagging follows by example).

## Test Plan

- [x] `bundle exec jekyll build` succeeds.
- [x] `my-claude-skills` page shows three articles, newest-first.
- [x] `rangelink-extension` page shows three articles, newest-first.
- [x] `couimet-github-io` and `millow-2025-02` (no tagged articles) render no section.
- [x] Disabled projects (cotton, micromouse, vacay) render no section.
- [x] Outlinks include `utm_campaign=project-<slug>`.

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/60
- Parent context: https://github.com/couimet/couimet.github.io/issues/59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project pages now display a dedicated section featuring all related articles, sorted by publication date
  * Article links include UTM tracking parameters for analytics visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->