### PR TITLE
[issues/59] Refresh `my-claude-skills` page and follow-along framing

### DIFF
--- a/follow-alongs/my-claude-skills-issues-10.md
+++ b/follow-alongs/my-claude-skills-issues-10.md
@@ -6,11 +6,17 @@ sequence: 300
 repourl: https://github.com/couimet/my-claude-skills/
 description: "A step-by-step execution of Claude skills where every decision, trace, and change is visible."
 summary: "Includes traces, evolving diffs, and the actual thinking behind each step."
+related_project: my-claude-skills
 labels:
   - ai
   - claude
   - skills
 ---
+
+<div class="alert alert-info" role="alert">
+  This follow-along is from March 2026. The toolkit has evolved since then — see the <a href="{{ site.baseurl }}/projects/my-claude-skills.html">project page</a> for current state and the articles below for newer ground.
+</div>
+
 
 <p>
   If you came here from my <a href="https://dev.to/couimet/from-vide-coding-to-supercharged-vibe-guiding-6nm" target="_blank" rel="noopener noreferrer">From Vide Coding to Supercharged Vibe Guiding</a> post, this is the part where we stop talking about the idea—and actually execute it.

--- a/projects/my-claude-skills.md
+++ b/projects/my-claude-skills.md
@@ -12,11 +12,8 @@ labels:
 summary: "A library of reusable Claude skills focused on developer workflows."
 ---
 
-The `my-claude-skills` repo is where I experiment with building a small, composable skill system for Claude: things like `/start-issue`, `/tackle-scratchpad-block`, `/question`, and `/commit-msg` that help me move from vague ideas to concrete code and docs.
+The `my-claude-skills` repo is where I experiment with building a small, composable skill system for Claude: workflow scaffolding that helps me move from vague ideas to concrete code and docs.
 
 Each skill focuses on one part of the developer workflow (planning, execution, questions, commits, etc.), but they really shine when composed into a full issue lifecycle.
 
-If you want to see these skills in action, start with:
-
-- The <a href="https://github.com/couimet/my-claude-skills#see-it-in-action" target="_blank" rel="noopener noreferrer"><code>See It In Action</code> section of the README</a>, which walks through the full issue lifecycle these skills are built around
-- The <a href="{{ site.baseurl }}/follow-alongs/my-claude-skills-issues-10.html">From Blank Issue to PR — With the Thinking Exposed</a> follow-along on this site, which mirrors that demo in a more narrative, portfolio-friendly format
+The <a href="https://github.com/couimet/my-claude-skills#see-it-in-action" target="_blank" rel="noopener noreferrer"><code>See It In Action</code> section of the README</a> is the best starting point for what's currently in the toolkit. The articles below trace how the workflow has changed over time. An earlier walkthrough, <a href="{{ site.baseurl }}/follow-alongs/my-claude-skills-issues-10.html">"From Blank Issue to PR — With the Thinking Exposed"</a>, mirrors one full issue lifecycle from March 2026; it's worth a read for the play-by-play, but the toolkit has moved on, so the articles below cover newer ground.


### PR DESCRIPTION
## Summary

The auto-rendered "Articles about this project" section shipped in #60 already provides the freshness signal the project page was missing. This PR trims the static prose that was duplicating that work or anchoring the page to a single March 2026 demo, and adds a banner on the follow-along itself so direct readers know the toolkit has moved on.

## Changes

- `projects/my-claude-skills.md`: drop the hardcoded skill list and the "If you want to see these skills in action" bullet list. The `#see-it-in-action` README anchor stays as the directed entry point. The follow-along is demoted to one sentence framed as the original walkthrough, with explicit signaling that the toolkit has evolved past it.
- `follow-alongs/my-claude-skills-issues-10.md`: add an alert banner at the top pointing readers to the project page for current state and to the articles for newer ground. Add `related_project: my-claude-skills` to the front matter as descriptive metadata (no layout consumer yet, by design).

## Test Plan

- [x] `bundle exec jekyll build` succeeds
- [x] `_site/projects/my-claude-skills.html` still renders the "Articles about this project" section with the three currently tagged articles
- [x] `_site/follow-alongs/my-claude-skills-issues-10.html` renders the new banner above the existing content

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/59
- Companion to #60, which added the auto-rendered articles section that lets this PR be a prose-only trim