### PR TITLE
[issues/63] Fix sync-resume CI pull with --autostash

### DIFF
--- a/.github/workflows/sync-resume.yml
+++ b/.github/workflows/sync-resume.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           git config user.name "github-actions"
           git config user.email "actions@github.com"
-          git pull --rebase origin main
+          git pull --rebase --autostash origin main
           git add -f resume.yml resume-full.html
           git commit -m "chore: sync YAML resume and HTML [skip ci]" || echo "No changes"
           git push


### PR DESCRIPTION
## Summary

The sync-resume CI workflow fails because `git pull --rebase origin main` refuses to rebase with unstaged changes. The script `sync-resume.sh` writes generated files into the working directory before the pull step runs. Adding `--autostash` tells Git to auto-stash before rebasing and re-apply after. This was a pre-existing fragility exposed by PR #65's changes to `resume.json`.

## Changes

- Added `--autostash` to `git pull --rebase origin main` in `.github/workflows/sync-resume.yml` line 24

## Test Plan

- [ ] The `sync-resume.yml` workflow runs successfully on push to main (validated by CI on next merge to main)
- [ ] Manual local check: `git pull --rebase --autostash origin main` succeeds with unstaged changes present

## Related

- Fix proposed in https://github.com/couimet/couimet.github.io/pull/65#issuecomment-4579600285
- Part of https://github.com/couimet/couimet.github.io/issues/63

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the resume synchronization workflow to improve handling of local changes during automated updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/couimet/couimet.github.io/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->