### PR TITLE
[issues/70] Add DeepSeek model-not-found fix article

### DIFF
--- a/_data/articles.json
+++ b/_data/articles.json
@@ -1,5 +1,11 @@
 [
   {
+    "date": "2026-06-04",
+    "title": "Fix: \"There's an issue with the selected model (deepseek-v4-pro)\" in Claude CLI",
+    "link": "TBD",
+    "anchor": "deepseek-model-not-found"
+  },
+  {
     "date": "2026-05-21",
     "title": "I sold you on /scratchpad. Then I migrated to /note.",
     "link": "https://dev.to/couimet/i-sold-you-on-scratchpad-then-i-migrated-to-note-4n1o",

--- a/_data/articles.json
+++ b/_data/articles.json
@@ -2,7 +2,7 @@
   {
     "date": "2026-06-04",
     "title": "Fix: \"There's an issue with the selected model (deepseek-v4-pro)\" in Claude CLI",
-    "link": "TBD",
+    "link": "https://dev.to/couimet/fix-theres-an-issue-with-the-selected-model-deepseek-v4-pro-in-claude-cli-44jg",
     "anchor": "deepseek-model-not-found"
   },
   {

--- a/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
+++ b/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
@@ -1,3 +1,10 @@
+---
+title: 'Eight env vars and Claude Code stops eating my paycheck'
+published: https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659
+tags: claudecode, deepseek, ai, productivity
+cover_image:
+---
+
 # Eight env vars and Claude Code stops eating my paycheck
 
 > **Update (2026-06-04):** Running into model errors with this setup? [Read the investigation here.](https://dev.to/couimet/fix-theres-an-issue-with-the-selected-model-deepseek-v4-pro-in-claude-cli-44jg)

--- a/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
+++ b/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
@@ -1,5 +1,7 @@
 # Eight env vars and Claude Code stops eating my paycheck
 
+> **Update (2026-06-04):** Running into model errors with this setup? [Read the investigation here →](TBD)
+
 DeepSeek's quick-start page has been live for months. I'm late to it.
 
 I love what Anthropic ships. Opus 4.7 is the best coding model I've used. I also can't run it all day on a family budget, and Pro's 5-hour quota wall stopped my flow more times than I want to count. So a few days ago I exported eight env vars, pointed Claude Code at DeepSeek, and went back to building [rangeLink](https://ouimet.info/projects/rangelink-extension.html). Since then I've only spent $4 and haven't seen a rate limit.

--- a/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
+++ b/articles/_sources/devto-post-2026-05-deepseek-and-claude-code.md
@@ -1,6 +1,6 @@
 # Eight env vars and Claude Code stops eating my paycheck
 
-> **Update (2026-06-04):** Running into model errors with this setup? [Read the investigation here →](TBD)
+> **Update (2026-06-04):** Running into model errors with this setup? [Read the investigation here.](https://dev.to/couimet/fix-theres-an-issue-with-the-selected-model-deepseek-v4-pro-in-claude-cli-44jg)
 
 DeepSeek's quick-start page has been live for months. I'm late to it.
 

--- a/articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md
+++ b/articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md
@@ -1,0 +1,79 @@
+---
+title: 'Fix: "There''s an issue with the selected model (deepseek-v4-pro)" in Claude CLI'
+published:
+tags: claudecode, deepseek, ai, debugging
+cover_image:
+---
+
+# Fix: "There's an issue with the selected model (deepseek-v4-pro)" in Claude CLI
+
+If you landed here from a search engine, here's the error you saw:
+
+```text
+There's an issue with the selected model (deepseek-v4-pro). It may not exist or you may not have access to it. Run /model to pick a different model.
+```
+
+You had the eight env vars from my [previous article](https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659) set. You opened a fresh terminal, typed `claude`, and got that. Same.
+
+A quick glossary for this article: `claude-code` is the brew package. `claude` is the command you type in your terminal.
+
+## I thought Anthropic was on to me
+
+I'll admit where my brain went first: Anthropic had patched `claude-code` to block non-Anthropic API keys. DeepSeek built a fully backwards-compatible API: same endpoints, same request shape, same response format. Anthropic ships a new `claude-code` version, I run `brew upgrade` without thinking, and suddenly my DeepSeek setup breaks. The timing was too clean.
+
+And here's the really self-absorbed part of this theory: my article explaining the DeepSeek setup had been live on dev.to for a couple weeks. It was getting reads. What if someone at Anthropic saw it and that was their "alright, that's enough" moment? A human being in San Francisco read my post, opened a Jira ticket, and a week later the validation shipped.
+
+Classic Coyote: draw the plan, check the ground later. Anthropic, a company with thousands of employees building frontier AI, was not reacting to my dev.to post. They probably have bigger things to worry about than one person's $10 DeepSeek bill. But the theory *felt* good, and the error message didn't give me much else to work with.
+
+I also googled the exact error string. Zero English results. A few forum posts, all written in 中文. That vacuum didn't help. When nobody in English is talking about an error, your brain writes its own screenplay. Mine went full [Wile E. Coyote](https://en.wikipedia.org/wiki/Wile_E._Coyote_and_the_Road_Runner), sketching elaborate traps that weren't there.
+
+## What was actually happening
+
+`claude` wasn't contacting DeepSeek at all. It was talking to Anthropic.
+
+The reason was a missing newline in my setup script. After publishing the original article, I'd moved the eight `export` lines into `~/point-to-deepseek.sh` so I could `source` the file instead of pasting the block into my terminal. API keys are like underwear: you don't share them, and pasting one into a terminal left it sitting in my scrollback for anyone to see.
+
+In that file, two lines had merged into one. The line starting with `export ANTHROPIC_BASE_URL=...` had the `export ANTHROPIC_AUTH_TOKEN=...` line glued to its end, with no newline between them. The shell saw one corrupt line. `ANTHROPIC_AUTH_TOKEN` never got exported. `ANTHROPIC_BASE_URL` got set to nonsense.
+
+Coyote looked down.
+
+```bash
+# what the shell saw (broken)
+export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic export ANTHROPIC_AUTH_TOKEN=sk-xxx
+
+# what it should look like (fixed)
+export ANTHROPIC_BASE_URL=https://api.deepseek.com/anthropic
+export ANTHROPIC_AUTH_TOKEN=sk-xxx
+```
+
+## A related edge case: resuming a DeepSeek session in an Anthropic context
+
+I said my panic was a false alarm, but one thing has actually changed since I wrote the original setup guide. When I first published it, I was routinely starting sessions on one provider and resuming them on the other — mostly DeepSeek sessions that I'd pick back up on Anthropic after my 5-hour quota reset. That stopped working about a week or two ago.
+
+If you start a `claude` session pointed at DeepSeek, `/exit`, then try to `/resume` it from a `claude` instance pointed at Anthropic, you get:
+
+```text
+API Error: 400 messages.1.content.0: Invalid `signature` in `thinking` block
+```
+
+The reverse still works. I resume Anthropic sessions on DeepSeek every day with no issues. So it's not a two-way wall — it's a one-way door, and it only catches you going in one direction.
+
+Whether it's a deliberate countermeasure or a format mismatch between two implementations of the same API is unconfirmed. But unlike my imaginary `claude-code` patch, this one is real.
+
+## Why I'm really writing this
+
+I said zero English results. That vacuum is the real reason this article exists. Somebody is going to hit this error, google it, and land here. That's the bet.
+
+And now I'm publishing a second article about a missing newline, SEO-optimized around an error message, hoping Google indexes it before the next person loses time to this.
+
+I'd spent half an hour convinced I was the protagonist in a David-and-Goliath story about API compatibility. Anthropic had noticed my workaround. They'd shipped a countermeasure. I was drafting the exposé in my head. Classic Coyote.
+
+The eight env vars still work. I'm still using them.
+
+---
+
+If you got here from the error message, I hope this saved you the 30 minutes I lost. Never saw the original setup? [It's here](https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659), and it still works.
+
+---
+
+*My friend Joel, after I shared [a recent article on LinkedIn](https://www.linkedin.com/feed/update/urn:li:activity:7463240605780074496/): "You can't teach old dogs new tricks, but you can force them to become LinkedIn influencers!" I am now publishing a second one about a missing newline. Yeah, I'm looking at you, dear Joel. 😉*

--- a/articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md
+++ b/articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md
@@ -1,6 +1,6 @@
 ---
 title: 'Fix: "There''s an issue with the selected model (deepseek-v4-pro)" in Claude CLI'
-published:
+published: https://dev.to/couimet/fix-theres-an-issue-with-the-selected-model-deepseek-v4-pro-in-claude-cli-44jg
 tags: claudecode, deepseek, ai, debugging
 cover_image:
 ---

--- a/articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md
+++ b/articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md
@@ -72,7 +72,7 @@ The eight env vars still work. I'm still using them.
 
 ---
 
-If you got here from the error message, I hope this saved you the 30 minutes I lost. Never saw the original setup? [It's here](https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659), and it still works.
+If you got here from the error message, I hope this saved you the 30 minutes I lost. Never saw the original setup? [It's here.](https://dev.to/couimet/eight-env-vars-and-claude-code-stops-eating-my-paycheck-2659)
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the dev.to article draft that explains the "There's an issue with the selected model (deepseek-v4-pro)" error. The root cause was a missing newline in a setup script that merged two export lines, leaving `ANTHROPIC_BASE_URL` unset while the DeepSeek model names took effect — causing claude to ask Anthropic's servers for a model it doesn't serve. The draft also documents the real cross-provider session resume asymmetry (DeepSeek-to-Anthropic only, not the reverse) discovered during investigation.

## Changes

- New `articles/_sources/devto-post-2026-06-deepseek-model-not-found-claude.md`: full draft with before/after code block showing the broken vs fixed export script, Wile E. Coyote arc built across three beats (plant at L19, unpack at L21, payoff at L40), Joel footer with LinkedIn link separated from the main arc, and no time-of-day anchors remaining

## Key Discoveries

- Zero English search results for the exact error string — the SEO gap this article fills is real and confirmed

## Test Plan

- [ ] Article source renders correctly in dev.to preview before publishing
- [ ] All links resolve: previous article, Wikipedia (Wile E. Coyote), LinkedIn post
- [ ] Before/after code block displays as expected on dev.to

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new article documenting a fix for the deepseek-v4-pro model issue in Claude CLI
  * Updated existing article with investigation details and resolution information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->