### PR TITLE
[issues/75] Add project pills to article list

### DIFF
--- a/_includes/articles/articles.html
+++ b/_includes/articles/articles.html
@@ -48,6 +48,26 @@
           >
             {{ article.title }}
           </a>
+          {% if article.projects %}
+            <span class="article-project-tags">
+              {% for project_slug in article.projects %}
+                {% assign proj_file = project_slug | append: ".md" %}
+                {% assign proj_page = site.pages | where: "name", proj_file | first %}
+                {% if proj_page %}
+                  {% assign proj_label = proj_page.title %}
+                  {% assign proj_url = proj_page.url %}
+                {% else %}
+                  {% assign proj_label = project_slug %}
+                  {% assign proj_url = nil %}
+                {% endif %}
+                {% if proj_url %}
+                  <a href="{{ proj_url | prepend: site.baseurl }}" class="badge rounded-pill article-project-pill">{{ proj_label }}</a>
+                {% else %}
+                  <span class="badge rounded-pill article-project-pill">{{ proj_label }}</span>
+                {% endif %}
+              {% endfor %}
+            </span>
+          {% endif %}
         </article>
       {% endfor %}
     </div>

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -268,6 +268,16 @@ li[id].anchor-pulse {
   color: var(--bs-white);
   font-size: 0.7rem;
   font-weight: 500;
+  transition: opacity 0.15s ease;
+}
+
+a.article-project-pill:hover {
+  opacity: 0.85;
+}
+
+a.article-project-pill:focus-visible {
+  outline: 2px solid var(--bs-link-color);
+  outline-offset: 2px;
 }
 
 @media (max-width: 767.98px) {

--- a/css/techfolio-theme/default.css
+++ b/css/techfolio-theme/default.css
@@ -255,6 +255,21 @@ li[id].anchor-pulse {
   color: var(--bs-link-color);
 }
 
+.article-project-tags {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-left: 0.4rem;
+  vertical-align: middle;
+}
+
+.article-project-pill {
+  background-color: var(--tf-pill-bg);
+  color: var(--bs-white);
+  font-size: 0.7rem;
+  font-weight: 500;
+}
+
 @media (max-width: 767.98px) {
   .articles-scroll {
     max-height: 260px;


### PR DESCRIPTION
## Summary

Articles in `_data/articles.json` that carry a `projects` array now show linked pill badges inline after the title on both the landing page and `/articles`. The pills resolve the project slug to a human-readable title (from the matching project page) and link to that project page.

## Changes

- `_includes/articles/articles.html`: after each article's title link, render an inline `<span class="article-project-tags">` containing one `badge rounded-pill article-project-pill` per project slug; Liquid looks up each slug against `site.pages` to get the real title and URL, falling back to the raw slug if no matching page exists
- `css/techfolio-theme/default.css`: added `.article-project-tags` (`inline-flex`, `margin-left: 0.4rem`, `vertical-align: middle`, `flex-wrap: wrap`, `gap: 0.25rem`) and `.article-project-pill` (`font-size: 0.7rem`, `font-weight: 500`, `background-color: var(--tf-pill-bg)`) — reuses the existing `--tf-pill-bg` variable already used by project card labels
- Documentation: CHANGELOG — not needed (no changelog file in this repo); README — not needed (visual enhancement, no new commands or settings)

## Test Plan

- [ ] All existing tests pass (no test suite in this repo)
- [ ] Manual testing: pills appear inline after titles on `/articles`; landing page articles section shows pills; articles without a `projects` field are unaffected; pills link to the correct project page

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Articles now display project tags as badges alongside metadata, enabling users to discover related projects
  * Project badges link to corresponding project pages for seamless navigation

* **Style**
  * Added new styling for project tag badges to enhance article card appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->