### PR TITLE
[issues/81] Make ouimet.info the canonical host for indexing

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Edit next line to provide your own name.
 title: Charles Ouimet | Professional Portfolio
 # Edit next line, replacing 'techfolios' with your github username
-url: "https://couimet.github.io"
+url: "https://ouimet.info"
 # Edit next line so that baseurl is "" if your repo is <username>.github.io
 baseurl: ""
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,7 @@
     <meta name="image" content="{{ site.data.bio.basics.picture }}">
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="{{ site.title | xml_escape }}">
+    <link rel="canonical" href="{{ url }}">
     <meta property="og:url" content="{{ url }}">
     <meta property="og:title" content="{{ title | xml_escape }}">
     <meta property="og:description" content="{{ description | xml_escape }}">


### PR DESCRIPTION
## Summary

Google Search Console reports `ouimet.info` as "Duplicate without user-selected canonical" and refuses to index it, because the same `_site/` is published to both `couimet.github.io` and `ouimet.info` with no canonical signal. Setting `site.url` to `https://ouimet.info` and adding a `<link rel="canonical">` to the shared `<head>` tells Google to consolidate indexing on `ouimet.info`.

## Changes

- `_config.yml`: change `url:` from `https://couimet.github.io` to `https://ouimet.info` so all generated metadata points at the preferred host.
- `_layouts/default.html`: add `<link rel="canonical" href="{{ url }}">` next to the existing `og:url` meta. Both deployments now emit the same canonical regardless of which host serves the page.
- Scope is indexability only. Internal nav still uses `site.baseurl` (empty), so visitors who land on `couimet.github.io` continue to navigate within `couimet.github.io`; no human-facing redirect is introduced.

## Test Plan

- [x] `bundle exec jekyll build --baseurl ""` succeeds locally.
- [x] Built HTML contains `<link rel="canonical" href="https://ouimet.info/...">` and matching `og:url` on representative pages (home, top-level page, nested project page).
- [ ] After deploy, re-request indexing for `ouimet.info` in Google Search Console and confirm the duplicate-without-canonical status clears.

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Site domain updated to ouimet.info
  * Added canonical URL tags to enhance search engine indexing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->