### PR TITLE
[issues/88] Add LinkedIn badges to project page article listings

### DIFF
--- a/_includes/projects/project-articles.html
+++ b/_includes/projects/project-articles.html
@@ -32,6 +32,7 @@
           >
             {{ article.title }}
           </a>
+          {% if article.promotion.linkedin.url %} <a href="{{ article.promotion.linkedin.url }}" target="_blank" rel="noopener noreferrer" title="View LinkedIn post"><svg class="tf-social"><use xlink:href="{{ '/img/bootstrap-icons.svg' | prepend: site.baseurl }}#linkedin"/></svg></a>{% endif %}
         </article>
       {% endfor %}
     </div>


### PR DESCRIPTION
## Summary

PR #80 added LinkedIn badges to the landing page and /articles/ page, but the project page article listing (`_includes/projects/project-articles.html`) was missed. This adds the same badge markup so articles with LinkedIn promotion data show the badge on project pages too.

## Changes

- Added the LinkedIn badge Liquid one-liner to `_includes/projects/project-articles.html`, matching the existing pattern in `_includes/articles/articles.html`

## Test Plan

- [ ] Manual: visit a project page that has related articles with LinkedIn promotion data (e.g. rangelink-extension) and confirm the badge renders
- [ ] Manual: visit a project page with related articles without LinkedIn promotion data and confirm no broken markup

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/88