### PR TITLE
[issues/86] Add opt-in `Buy Me a Coffee` badge to project pages

### DIFF
--- a/_includes/projects/project-buy-me-a-coffee.html
+++ b/_includes/projects/project-buy-me-a-coffee.html
@@ -1,0 +1,5 @@
+<h2 class="h5 mt-4 mb-2">Support</h2>
+
+<a href="https://www.buymeacoffee.com/couimet" target="_blank">
+  <img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;">
+</a>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -38,6 +38,8 @@ layout: home
   </div>
 
   {% include projects/project-articles.html %}
+
+  {% if page.showBuyMeACoffee %}{% include projects/project-buy-me-a-coffee.html %}{% endif %}
 </div>
 
 <p class="text-center pt-4"><a href="{{ site.baseurl}}/projects/">See all projects</a></p>

--- a/projects/my-claude-skills.md
+++ b/projects/my-claude-skills.md
@@ -10,6 +10,7 @@ labels:
   - skills
   - workflows
 summary: "A library of reusable Claude skills focused on developer workflows."
+showBuyMeACoffee: true
 ---
 
 The `my-claude-skills` repo is where I experiment with building a small, composable skill system for Claude: workflow scaffolding that helps me move from vague ideas to concrete code and docs.

--- a/projects/rangelink-extension.md
+++ b/projects/rangelink-extension.md
@@ -14,6 +14,7 @@ labels:
   - extension
   - productivity
 summary: "One keybinding to share precise, clickable code ranges with any AI or tool."
+showBuyMeACoffee: true
 ---
 
 RangeLink gives you a single muscle memory for AI-assisted development: select code, hit your RangeLink shortcut, and get a GitHub-style link with character-level ranges that works in PRs, chats, terminals, and docs. It removes copy/paste friction and shortcut-juggling between Claude, Cursor, GPT, and other tools by piping links straight into your bound destinations, so your AI always sees exactly the slice of code you mean.


### PR DESCRIPTION
## Summary

Projects can now show a Buy Me a Coffee badge at the bottom of their page by setting `showBuyMeACoffee: true` in frontmatter. The badge links to `buymeacoffee.com/couimet` and appears after the related articles list, styled consistently with existing page sections.

## Changes

- New `_includes/projects/project-buy-me-a-coffee.html` with the badge markup and Support heading
- `_layouts/project.html` renders the include when `page.showBuyMeACoffee` is set
- RangeLink Extension and my-claude-skills project pages opted in via the new frontmatter flag

## Test Plan

- [ ] Jekyll build passes with no errors
- [ ] Badge renders on /projects/rangelink-extension.html
- [ ] Badge renders on /projects/my-claude-skills.html
- [ ] Badge absent from projects that haven't opted in

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/86