### PR TITLE
[issues/105] Fix `sync-resume` CI: strip internal-only fields before JSON→YAML conversion

### DIFF
--- a/scripts/sync-resume.sh
+++ b/scripts/sync-resume.sh
@@ -31,20 +31,29 @@ fi
 
 echo "==> Converting resume.json → resume.yml (json2yamlresume)"
 docker run --rm -t \
-  --user "$(id -u):$(id -g)" \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
   -e HOME=/tmp \
   -v "$REPO_ROOT:/work" \
   -w /work \
   node:22-alpine \
-  sh -c "echo '  → Running json2yamlresume...' && npx --yes json2yamlresume@$PINNED_J2Y_VERSION resume.json resume.yml && echo '  → Patching country code for yamlresume compatibility...' && sed -i 's/^    country: CA$/    country: Canada/' resume.yml"
+  sh -c "apk add --no-cache jq >/dev/null 2>&1 && \
+    echo '  → Stripping internal-only fields...' && \
+    jq 'del(.basics.keywordSubTag) | walk(if type == \"object\" then with_entries(select(.key | startswith(\"docx\") | not)) else . end)' resume.json > /tmp/clean-resume.json && \
+    echo '  → Running json2yamlresume...' && \
+    npx --yes json2yamlresume@$PINNED_J2Y_VERSION /tmp/clean-resume.json resume.yml && \
+    echo '  → Patching country code for yamlresume compatibility...' && \
+    sed -i 's/^    country: CA$/    country: Canada/' resume.yml && \
+    chown \$HOST_UID:\$HOST_GID resume.yml"
 
 echo "==> Building resume-full.html (yamlresume)"
 docker run --rm -t \
-  --user "$(id -u):$(id -g)" \
+  -e HOST_UID="$(id -u)" \
+  -e HOST_GID="$(id -g)" \
   -e HOME=/tmp \
   -v "$REPO_ROOT:/work" \
   -w /work \
   node:22-alpine \
-  sh -c "echo '  → Running yamlresume build...' && npx --yes yamlresume@$PINNED_YR_VERSION build resume.yml --no-pdf -o /tmp/out && cp /tmp/out/resume.html resume-full.html"
+  sh -c "echo '  → Running yamlresume build...' && npx --yes yamlresume@$PINNED_YR_VERSION build resume.yml --no-pdf -o /tmp/out && cp /tmp/out/resume.html resume-full.html && chown \$HOST_UID:\$HOST_GID resume-full.html"
 
 echo "==> Done: resume.yml and resume-full.html generated"

--- a/tests/sync-resume.bats
+++ b/tests/sync-resume.bats
@@ -144,6 +144,121 @@ EOF
   [ "$status" -eq 0 ]
 }
 
+# --- Internal field stripping (unit) ---
+
+JQ_STRIP_FILTER='del(.basics.keywordSubTag) | walk(if type == "object" then with_entries(select(.key | startswith("docx") | not)) else . end)'
+
+# Create a minimal resume.json fixture with internal fields and run the jq strip filter.
+# $1: optional Python fragment to merge extra data into the fixture.
+# $2: output basename (default: stripped).
+run_strip() {
+  local extra="${1:-}"
+  local out="${2:-stripped}"
+  python3 -c "
+import json
+data = {
+  'basics': {
+    'name': 'Test User',
+    'label': 'Developer',
+    'keywordSubTag': ['Architecture', 'Observability']
+  },
+  'work': [
+    {'name': 'Acme', 'position': 'Dev', 'docxLastRoleBeforeEarlierExperience': True},
+    {'name': 'Beta', 'position': 'Lead'}
+  ]
+}
+$extra
+with open('$BATS_TEST_TMPDIR/fixture.json', 'w') as f:
+    json.dump(data, f)
+"
+  run jq "$JQ_STRIP_FILTER" "$BATS_TEST_TMPDIR/fixture.json"
+  # Write stripped output to a file for subsequent assertions.
+  jq "$JQ_STRIP_FILTER" "$BATS_TEST_TMPDIR/fixture.json" \
+    > "$BATS_TEST_TMPDIR/${out}.json"
+}
+
+@test "strip removes keywordSubTag from basics" {
+  run_strip
+  [ "$status" -eq 0 ]
+  run jq -r '.basics | has("keywordSubTag")' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" = "false" ]
+}
+
+@test "strip removes docxLastRoleBeforeEarlierExperience from work" {
+  run_strip
+  [ "$status" -eq 0 ]
+  run jq -r '.work | tostring | contains("docxLastRoleBeforeEarlierExperience")' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" = "false" ]
+}
+
+@test "strip removes docxSkip from certificates" {
+  run_strip '
+data["certificates"] = [
+  {"name": "Cert A", "docxSkip": True},
+  {"name": "Cert B"}
+]'
+  [ "$status" -eq 0 ]
+  run jq -r '.certificates | tostring | contains("docxSkip")' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" = "false" ]
+}
+
+@test "strip removes docxSkip from education, volunteer, awards, projects" {
+  run_strip '
+data["education"] = [{"institution": "U", "docxSkip": True}];
+data["volunteer"] = [{"organization": "Org", "docxSkip": True}];
+data["awards"] = [{"title": "Prize", "docxSkip": True}];
+data["projects"] = [{"name": "Proj", "docxSkip": True}]'
+  [ "$status" -eq 0 ]
+  run jq -r '[(.education,.volunteer,.awards,.projects) | tostring] | join(" ")' "$BATS_TEST_TMPDIR/stripped.json"
+  [[ "$output" != *"docxSkip"* ]]
+}
+
+@test "strip preserves standard fields" {
+  run_strip
+  [ "$status" -eq 0 ]
+  run jq -r '.basics.name' "$BATS_TEST_TMPDIR/stripped.json"
+  [[ "$output" == *"Test User"* ]]
+  run jq -r '.basics.label' "$BATS_TEST_TMPDIR/stripped.json"
+  [[ "$output" == *"Developer"* ]]
+  run jq -r '.work[0].name' "$BATS_TEST_TMPDIR/stripped.json"
+  [[ "$output" == *"Acme"* ]]
+  run jq -r '.work[1].position' "$BATS_TEST_TMPDIR/stripped.json"
+  [[ "$output" == *"Lead"* ]]
+}
+
+@test "strip preserves section entries without docx fields" {
+  run_strip '
+data["certificates"] = [{"name": "Cert A"}, {"name": "Cert B"}]'
+  [ "$status" -eq 0 ]
+  run jq '.certificates | length' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" -eq 2 ]
+}
+
+@test "strip handles missing optional sections" {
+  run_strip
+  [ "$status" -eq 0 ]
+  run jq -r '.basics | has("keywordSubTag")' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" = "false" ]
+}
+
+@test "strip preserves non-docx-prefixed fields with docx in the name" {
+  run_strip '
+data["work"][0]["needs_docx_review"] = True;
+data["work"][0]["mydocx"] = True'
+  [ "$status" -eq 0 ]
+  run jq -r '.work[0] | has("needs_docx_review")' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" = "true" ]
+  run jq -r '.work[0] | has("mydocx")' "$BATS_TEST_TMPDIR/stripped.json"
+  [ "$output" = "true" ]
+}
+
+@test "strip handles empty JSON object without error" {
+  echo '{}' > "$BATS_TEST_TMPDIR/empty.json"
+  run jq "$JQ_STRIP_FILTER" "$BATS_TEST_TMPDIR/empty.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == "{}" ]]
+}
+
 # --- Integration: resume.yml output validation ---
 
 @test "resume.yml exists after sync" {


### PR DESCRIPTION
## Summary

The sync-resume CI pipeline broke after https://github.com/couimet/couimet.github.io/pull/107 because custom internal-only fields (`keywordSubTag`, `docxSkip`, `docxLastRoleBeforeEarlierExperience`) added to `resume.json` for the Python extract/lint pipeline leaked through `json2yamlresume` into `resume.yml`, where `yamlresume` crashed with `n.replace is not a function` on the `keywordSubTag` array.

## Changes

- Added a `jq` filtering step in `scripts/sync-resume.sh` that strips `keywordSubTag` from `basics` and uses `walk` to recursively remove all `docx*`-prefixed keys from every object in the JSON before conversion — no need to enumerate sections individually
- Replaced `--user` with `HOST_UID`/`HOST_GID` env vars and `chown` on generated files so `apk add jq` can run as root inside the `node:22-alpine` container while output files retain correct ownership
- Added 9 unit tests in `tests/sync-resume.bats` covering keywordSubTag removal, docx-prefixed field stripping across all sections, standard field preservation, `startswith` prefix semantics, and empty-input handling

## Key Discoveries

- Custom fields in JSON Resume are passed through verbatim by `json2yamlresume` but crash `yamlresume` when the type doesn't match its schema expectations (array where a string is expected)
- `jq`'s `walk` function makes recursive key deletion a one-liner — any future `docx*`-prefixed field added anywhere in `resume.json` is automatically stripped without code changes
- The `docx*` prefix naming convention makes internal fields both discoverable and consistently strippable without maintaining an allowlist per section

## Test Plan

- [x] `scripts/sync-resume.sh` completes without errors and generates valid `resume-full.html`
- [x] All 20 relevant BATS tests pass (9 new stripping tests + 11 pre-existing); 2 pre-existing integration tests on stale `resume.yml` will pass after CI regenerates it
- [x] No internal fields leak into the generated `resume.yml`
- [x] Country code patch (`CA` → `Canada`) still applies correctly
- [x] `make extract-resume` still works (reads original `resume.json` with internal fields intact)
- [x] `make lint-fix` passes with no changes

## Related

Part of https://github.com/couimet/couimet.github.io/issues/105

@coderabbitai ignore