### PR TITLE
[issues/114] Timestamp suffix on generated resume extract files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ _site/
 
 resume.yml
 resume-full.html
-resume-docx-content.txt
+resume-docx-content-*.txt
 
 # Python venvs and caches
 .venv/

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Converts `resume.json` → `resume.yml` (YAMLResume) → `resume-full.html` (sty
 Generates a plain-text file from `resume.json` for copy-paste into a formatted `.docx` resume. Sections are delimited with `#`-prefixed comments. Work roles up to and including the `lastRoleBeforeEarlierExperience` marker get full bullet treatment; older roles appear in an Earlier Experience summary block with a CTA placeholder for an AI-generated narrative.
 
 ```bash
-make extract-resume                # → resume-docx-content.txt
+make extract-resume                # → resume-docx-content-YYYYMMDD-HHMMSS.txt
 ```
 
 ### Docx linting

--- a/scripts/extract-resume-text.py
+++ b/scripts/extract-resume-text.py
@@ -11,6 +11,7 @@ cutoff between full-bullet roles and the Earlier Experience summary block.
 import argparse
 import json
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from resume_utils import fmt_date, get_cutoff
@@ -243,8 +244,8 @@ def main() -> None:
     )
     parser.add_argument(
         "--output",
-        default="resume-docx-content.txt",
-        help="Output path for the generated text file (default: resume-docx-content.txt)",
+        default=f"resume-docx-content-{datetime.now().strftime('%Y%m%d-%H%M%S')}.txt",
+        help="Output path for the generated text file (default: resume-docx-content-YYYYMMDD-HHMMSS.txt)",
     )
     args = parser.parse_args()
 

--- a/tests/extract-resume-text.bats
+++ b/tests/extract-resume-text.bats
@@ -157,3 +157,42 @@ with open('$BATS_TEST_TMPDIR/no-skip-resume.json', 'w') as f:
   [ "$status" -eq 0 ]
   [ "$output" -ge 1 ]
 }
+
+# --- Timestamped default output filename ---
+
+@test "extract-resume-text default output uses timestamped filename" {
+  cd "$BATS_TEST_TMPDIR"
+  run uv run python "$SCRIPT" --input "$RESUME_JSON"
+  [ "$status" -eq 0 ]
+  # Find the generated file matching the timestamped pattern
+  count=$(find . -maxdepth 1 -name 'resume-docx-content-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].txt' | wc -l)
+  [ "$count" -eq 1 ]
+}
+
+@test "extract-resume-text default output file has section headers" {
+  cd "$BATS_TEST_TMPDIR"
+  run uv run python "$SCRIPT" --input "$RESUME_JSON"
+  [ "$status" -eq 0 ]
+  output_file=$(find . -maxdepth 1 -name 'resume-docx-content-*.txt' | head -1)
+  [ -n "$output_file" ]
+  run grep -c "^# Work Experience$" "$output_file"
+  [ "$status" -eq 0 ]
+  [ "$output" -ge 1 ]
+}
+
+@test "extract-resume-text explicit --output overrides timestamped default" {
+  run_extract
+  [ "$status" -eq 0 ]
+  [ -f "$OUTPUT" ]
+  # The custom path should be exactly as specified, not timestamped
+  [ "$(basename "$OUTPUT")" = "output.txt" ]
+}
+
+@test "extract-resume-text two runs produce different default filenames" {
+  cd "$BATS_TEST_TMPDIR"
+  uv run python "$SCRIPT" --input "$RESUME_JSON"
+  sleep 1
+  uv run python "$SCRIPT" --input "$RESUME_JSON"
+  count=$(find . -maxdepth 1 -name 'resume-docx-content-*.txt' | wc -l)
+  [ "$count" -eq 2 ]
+}


### PR DESCRIPTION
## Summary

`make extract-resume` now writes to a timestamped filename (`resume-docx-content-YYYYMMDD-HHMMSS.txt`) instead of always overwriting `resume-docx-content.txt`. This makes the before/after diffing workflow straightforward: run before editing, run after, diff the two outputs. The `--output` flag still accepts an explicit path for CI and Makefile targets that need a fixed name.

## Changes

- Default output filename in `scripts/extract-resume-text.py` now includes a startup-time timestamp computed via `datetime.now()`. No new dependencies.
- `.gitignore` pattern updated from the literal `resume-docx-content.txt` to the wildcard `resume-docx-content-*.txt` to cover all timestamped variants.
- README updated to reflect the new timestamped filename convention.
- 4 new BATS tests in `tests/extract-resume-text.bats` cover: default timestamped filename, content correctness with default output, explicit `--output` override, and two-run uniqueness.

## Test Plan

- [x] All 16 BATS tests pass (12 existing + 4 new)
- [ ] Manual: `make extract-resume` produces a timestamped file matching `resume-docx-content-YYYYMMDD-HHMMSS.txt`

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/114

@coderabbitai ignore