### PR TITLE
[issues/120] Add Kafka to career changelog and resume skills

### DIFF
--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -56,6 +56,7 @@
         <li>Use of <a href="https://sorbet.org/" target="_blank" rel="noopener noreferrer">Sorbet</a>, <a href="https://github.com/ruby/rbs" target="_blank" rel="noopener noreferrer">RBS</a>, and inline RBS for type checking.</li>
         <li>Use of <a href="https://redis.io/" target="_blank" rel="noopener noreferrer">Redis</a>.</li>
         <li>Use of <a href="https://graphql.org/" target="_blank" rel="noopener noreferrer">GraphQL</a>.</li>
+        <li>Use of <a href="https://kafka.apache.org/" target="_blank" rel="noopener noreferrer">Kafka</a>.</li>
         <li>Use of <a href="https://docusaurus.io/" target="_blank" rel="noopener noreferrer">Docusaurus</a> for internal documentation.</li>
         <li>Use of <a href="https://graphite.dev/" target="_blank" rel="noopener noreferrer">Graphite</a>.</li>
         <li>Use of <a href="https://buildkite.com/" target="_blank" rel="noopener noreferrer">Buildkite</a>.</li>

--- a/resume.json
+++ b/resume.json
@@ -313,6 +313,7 @@
         "CloudWatch",
         "Parameter Store",
         "Serverless Framework",
+        "Kafka",
         "Docker",
         "Kubernetes",
         "Redis",


### PR DESCRIPTION
## Summary

Adds Apache Kafka as a technology first used at Shopify (2025-2026) to the career changelog and surfaces it in resume.json skills so it flows through to the PDF resume and LinkedIn extraction.

## Changes

- Career changelog: "Use of Kafka" bullet added to Shopify 8.0.0 Added section (`_includes/career/changelog.html`), following the additive first-mention convention
- Resume skills: "Kafka" keyword added to the Cloud, Infrastructure & Distributed Systems group in `resume.json`, covering the PDF resume and LinkedIn extraction

## Test Plan

- [x] All existing tests pass (4 pre-existing BATS failures unrelated to this change: Python 3.9 incompatibility with `str | None` union syntax)
- [ ] Manual testing: verify Kafka renders on the changelog page and in LinkedIn extraction output

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/120