### PR TITLE
[issues/129] Add Dependabot version-update config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+updates:
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Toronto'
+    groups:
+      deps:
+        patterns:
+          - '*'
+  - package-ecosystem: 'uv'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Toronto'
+    groups:
+      deps:
+        patterns:
+          - '*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'America/Toronto'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary

Enables automated weekly dependency updates for all three package ecosystems in this repo. Part of an account-wide Dependabot rollout.

## Changes

- Dependabot enabled for Ruby/Bundler with weekly Monday grouped PRs
- Dependabot enabled for Python/uv with weekly Monday grouped PRs (uses the native `uv` ecosystem for correct `uv.lock` handling)
- Dependabot enabled for GitHub Actions with weekly Monday grouped PRs (keeps action SHA pins current)

## Key Discoveries

- Dependabot's `pip` ecosystem does not understand `uv.lock` and would leave it stale on every bump. The `uv` ecosystem (GA since March 2025) handles both `pyproject.toml` and `uv.lock` in tandem and is the correct choice for this repo.

## Test Plan

- [x] YAML syntax validated
- [ ] New tests added for: none (config file only)
- [ ] Manual testing: Dependabot validates the config on merge

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/129

Generated by /finish-issue v2026.07.14.3@8469237 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Set up automated weekly update checks for dependency and GitHub Actions changes, scheduled every Monday at 09:00 (America/Toronto).
  * Configured updates to group related dependency/action changes together (including Bundler, UV, and GitHub Actions) to make maintenance and review simpler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->