### PR TITLE
[issues/138] Update pinned `json2yamlresume` and `yamlresume` to `0.13.2`

### DIFF
--- a/scripts/sync-resume.sh
+++ b/scripts/sync-resume.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PINNED_J2Y_VERSION="0.13.1"
-PINNED_YR_VERSION="0.13.1"
+PINNED_J2Y_VERSION="0.13.2"
+PINNED_YR_VERSION="0.13.2"
 
 echo "==> Checking for newer tool versions..."
 

--- a/tests/sync-resume.bats
+++ b/tests/sync-resume.bats
@@ -43,7 +43,7 @@ EOF
 
 # Full mocks: both npm and docker stubbed.
 mock_all() {
-  mock_npm "${1:-0.13.1}" "${2:-0.13.1}"
+  mock_npm "${1:-0.13.2}" "${2:-0.13.2}"
   mock_docker
 }
 
@@ -54,7 +54,7 @@ run_script() {
 # --- Version check: happy path ---
 
 @test "version check passes when both packages match pinned versions" {
-  mock_all "0.13.1" "0.13.1"
+  mock_all "0.13.2" "0.13.2"
   run_script
   [ "$status" -eq 0 ]
 }
@@ -62,18 +62,18 @@ run_script() {
 # --- Version check: abort paths ---
 
 @test "version check aborts when json2yamlresume is behind latest" {
-  mock_npm "0.14.0" "0.13.1"
+  mock_npm "0.14.0" "0.13.2"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"json2yamlresume is pinned at 0.13.1 but 0.14.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at 0.13.2 but 0.14.0 is available"* ]]
   [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
 }
 
 @test "version check aborts when yamlresume is behind latest" {
-  mock_npm "0.13.1" "0.14.0"
+  mock_npm "0.13.2" "0.14.0"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"yamlresume is pinned at 0.13.1 but 0.14.0 is available"* ]]
+  [[ "$output" == *"yamlresume is pinned at 0.13.2 but 0.14.0 is available"* ]]
   [[ "$output" == *"Update PINNED_YR_VERSION"* ]]
 }
 
@@ -82,20 +82,20 @@ run_script() {
   run_script
   [ "$status" -eq 1 ]
   # Should fail on the first check (json2yamlresume) and never reach yamlresume
-  [[ "$output" == *"json2yamlresume is pinned at 0.13.1 but 0.14.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at 0.13.2 but 0.14.0 is available"* ]]
 }
 
 # --- Version check: offline fallback ---
 
 @test "version check continues when json2yamlresume npm query fails" {
-  mock_npm "fail" "0.13.1"
+  mock_npm "fail" "0.13.2"
   mock_docker
   run_script
   [ "$status" -eq 0 ]
 }
 
 @test "version check continues when yamlresume npm query fails" {
-  mock_npm "0.13.1" "fail"
+  mock_npm "0.13.2" "fail"
   mock_docker
   run_script
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

The Sync JSON → YAML Resume workflow fails on push to main because `json2yamlresume` published `0.13.2` and the version-check in `scripts/sync-resume.sh` exits with code 1 when the pinned version doesn't match npm. `yamlresume` also released `0.13.2` so both pins are bumped together to prevent a follow-up failure.

## Changes

- Bumped `PINNED_J2Y_VERSION` and `PINNED_YR_VERSION` from `0.13.1` to `0.13.2` in `scripts/sync-resume.sh`
- Updated test mock values and assertion strings in `tests/sync-resume.bats` to match the new pinned versions

## Test Plan

- [ ] All existing tests pass — specifically the 27 `sync-resume.bats` tests
- [ ] CI workflow `Sync JSON → YAML Resume` succeeds on push to main

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/138

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@codeabbitai ignore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resume generation tools to version 0.13.2 for more consistent builds.
  * Preserved existing conversion, validation, and offline fallback behavior.

* **Tests**
  * Updated automated checks to verify the new tool versions and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->