### PR TITLE
[issues/148] Exclude dev files and internal data from Jekyll output

### DIFF
--- a/.snapshots/sitemap.xml
+++ b/.snapshots/sitemap.xml
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://ouimet.info/resume-full.html</loc>
-    <lastmod>2026-07-16T21:07:09-04:00</lastmod>
+    <lastmod>2026-07-25T19:49:53-04:00</lastmod>
   </url>
   <url>
     <loc>https://ouimet.info/resume.html</loc>

--- a/_config.yml
+++ b/_config.yml
@@ -21,18 +21,26 @@ kramdown:
 strict_front_matter: true
 mathjax: true
 exclude:
+  - articles/_sources
   - CLAUDE.md
   - Gemfile
   - Gemfile.lock
-  - LICENSE
-  - README.md
   - .history
-  - articles/_sources
+  - LICENSE
+  - Makefile
+  - micro-projects/network-nudge/eslint.config.js
   - micro-projects/network-nudge/node_modules
+  - micro-projects/network-nudge/package.json
+  - micro-projects/network-nudge/pnpm-lock.yaml
+  - micro-projects/network-nudge/vitest.config.js
+  - pyproject.toml
+  - README.md
+  - resume-docx-content-*.txt
+  - resume-linkedin-content-*.txt
   - scripts
-include:
-  - .nojekyll
-  - _data
+  - tests
+  - uv.lock
+include: []
 plugins:
   - jekyll-gist
   - jekyll-sitemap


### PR DESCRIPTION
## Summary

The `deploy-ouimet-info.yml` workflow copies `_site/` to the ouimet.info production server. Several dev-tooling files and internal data directories were leaking into that output because `_config.yml` didn't exclude them. This tightens the exclude list and removes two unnecessary includes that served no purpose on the Apache host.

## Changes

- Dev tooling files (`Makefile`, `pyproject.toml`, `uv.lock`, `tests/`) are now excluded from the Jekyll build output
- Micro-project dev config files (`eslint.config.js`, `package.json`, `pnpm-lock.yaml`, `vitest.config.js` under `micro-projects/network-nudge/`) are excluded; runtime assets and `src/` remain available as before, and `node_modules/` exclusion is preserved
- `.nojekyll` and `_data/` are no longer copied into `_site/`: `.nojekyll` only matters for GitHub's default Jekyll builder (useless on Apache), and `_data/` is consumed by Jekyll at build time via `site.data.*` regardless of the `include` setting
- Generated local-only resume content files (`resume-docx-content-*.txt`, `resume-linkedin-content-*.txt`) are excluded so local builds stay clean (already gitignored, but Jekyll copied them)
- The exclude list is alphabetized (ignoring leading dots), with `include: []` kept as an explicit empty list

## Test Plan

- [x] All existing tests pass (4 pre-existing failures in `extract-resume-linkedin.bats` are unrelated)
- [x] `make snapshot-sitemap` regenerated `.snapshots/sitemap.xml` (timestamp-only change; excluded files were never pages)
- [ ] Manual: verify `_site/` no longer contains excluded files after `bundle exec jekyll build`

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/148

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore