### PR TITLE
[issues/147] Add RangeLink 1.2K installs promotion

### DIFF
--- a/_data/promotions.yml
+++ b/_data/promotions.yml
@@ -5,6 +5,28 @@
 # context: free-form text — a link, description, or project reference.
 # Channels are keyed by name (linkedin, x, etc.), each with url and content.
 
+- date: "2026-07-30"
+  context: https://open-vsx.org/extension/couimet/rangelink-vscode-extension
+  projects:
+    - rangelink-extension
+  summary: "1.2K installs"
+  linkedin:
+    url: https://www.linkedin.com/feed/update/urn:li:activity:7488679852728840192/
+    content: |
+      RangeLink crossed 1.2K installs on the OpenVSX registry (Cursor extensions marketplace).
+
+      A tool I built for myself scratches the same itch for a lot of other people. If you're one of the 1.2K — thank you. I had a feeling other people were hitting the same wall I was. Didn't expect 1.2K of them. 😅
+
+      👉 https://ouimet.info/projects/rangelink-extension
+  x:
+    url: https://x.com/charlesouimet/status/2082916440110178810
+    content: |
+      RangeLink crossed 1.2K installs on OpenVSX Registry/Cursor.
+
+      I built it for me. 1.2K other people had the same problem. If you're one of them — thank you. 😅
+
+      👉 https://ouimet.info/projects/rangelink-extension
+
 - date: "2026-07-07"
   context: https://ouimet.info/projects/network-nudge.html
   projects:

--- a/projects/rangelink-extension.md
+++ b/projects/rangelink-extension.md
@@ -26,8 +26,8 @@ RangeLink gives you a single muscle memory for AI-assisted development: select c
 
 <h2 class="h5 mt-4 mb-2">Install</h2>
 
-- **VS Code Marketplace**: [`couimet.rangelink-vscode-extension`](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 - **Open VSX Registry**: [`couimet/rangelink-vscode-extension`](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
+- **VS Code Marketplace**: [`couimet.rangelink-vscode-extension`](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 
 <h2 class="h5 mt-4 mb-2">Core library</h2>
 


### PR DESCRIPTION
## Summary

RangeLink crossed 1.2K installs on the OpenVSX registry. This adds a social media promotion entry (LinkedIn + X) to `_data/promotions.yml` and reorders the project page install links to list OpenVSX first.

## Changes

- New promotion entry in `_data/promotions.yml` celebrating RangeLink's 1.2K install milestone on the OpenVSX registry, with per-platform post content for LinkedIn and X
- OpenVSX Registry listed ahead of VS Code Marketplace in the install section on the RangeLink project page — it drives significantly more installs

## Key Discoveries

The `project-featured-in.html` template already handles the mix of articles and promotions — promotions without a title render as "Post" badges with summary text and platform icons. No template changes were needed for the new entry to surface in the Featured In section.

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/147

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore