### PR TITLE
[issues/158] Add `shields.io` badges to RangeLink project page

### DIFF
--- a/projects/rangelink-extension.md
+++ b/projects/rangelink-extension.md
@@ -26,8 +26,8 @@ RangeLink gives you a single muscle memory for AI-assisted development: select c
 
 <h2 class="h5 mt-4 mb-2">Install</h2>
 
-- **Open VSX Registry**: [`couimet/rangelink-vscode-extension`](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
-- **VS Code Marketplace**: [`couimet.rangelink-vscode-extension`](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
+- **Open VSX Registry**: [`couimet/rangelink-vscode-extension`](https://open-vsx.org/extension/couimet/rangelink-vscode-extension) [![Version](https://img.shields.io/open-vsx/v/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension) [![Downloads](https://img.shields.io/open-vsx/dt/couimet/rangelink-vscode-extension?label=Open%20VSX%20%2F%20Cursor%20Downloads&color=blue)](https://open-vsx.org/extension/couimet/rangelink-vscode-extension)
+- **VS Code Marketplace**: [`couimet.rangelink-vscode-extension`](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension) [![Version](https://vsmarketplacebadges.dev/version/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension) [![Installs](https://vsmarketplacebadges.dev/downloads-short/couimet.rangelink-vscode-extension.svg)](https://marketplace.visualstudio.com/items?itemName=couimet.rangelink-vscode-extension)
 
 <h2 class="h5 mt-4 mb-2">Core library</h2>
 


### PR DESCRIPTION
## Summary

Add live version and download/install badge images alongside each marketplace link in the Install section of the RangeLink project page, matching the badges added to the rangeLink READMEs in PR [#704](https://github.com/couimet/rangeLink/pull/704).

## Changes

- RangeLink project page Install section: Open VSX Registry line now shows live version and downloads badges from shields.io; VS Code Marketplace line now shows live version and installs badges from vsmarketplacebadges.dev

## Test Plan

- [x] All existing tests pass
- [ ] Manual testing: visual inspection of the project page

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/158

Generated by /finish-issue v2026.07.22@9fcae14 • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore