### PR TITLE
[issues/160] Update `yamlresume` dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-prereqs install-deps install-hooks serve build test lint lint-fix markdownlint markdownlint-fix snapshot-sitemap verify-sitemap validate-articles validate-promotions extract-resume lint-resume nudge-test nudge-lint nudge-fix banner banner-default banner-rangelink banner-network-nudge banner-rabbit-maximizer
+.PHONY: install install-prereqs install-deps install-hooks serve build test lint lint-fix markdownlint markdownlint-fix snapshot-sitemap verify-sitemap validate-articles validate-promotions extract-resume extract-resume-linkedin sync-resume lint-resume nudge-test nudge-lint nudge-fix banner banner-default banner-rangelink banner-network-nudge banner-rabbit-maximizer
 
 install: install-prereqs install-deps install-hooks
 
@@ -62,6 +62,9 @@ extract-resume:
 
 extract-resume-linkedin:
 	uv run python scripts/extract-resume-linkedin.py
+
+sync-resume:
+	./scripts/sync-resume.sh
 
 lint-resume:
 	@if [ -z "$(DOCX)" ]; then \

--- a/scripts/sync-resume.sh
+++ b/scripts/sync-resume.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PINNED_J2Y_VERSION="0.13.2"
-PINNED_YR_VERSION="0.13.2"
+PINNED_J2Y_VERSION="0.14.0"
+PINNED_YR_VERSION="0.14.0"
 
 echo "==> Checking for newer tool versions..."
 

--- a/tests/sync-resume.bats
+++ b/tests/sync-resume.bats
@@ -43,7 +43,7 @@ EOF
 
 # Full mocks: both npm and docker stubbed.
 mock_all() {
-  mock_npm "${1:-0.13.2}" "${2:-0.13.2}"
+  mock_npm "${1:-0.14.0}" "${2:-0.14.0}"
   mock_docker
 }
 
@@ -54,7 +54,7 @@ run_script() {
 # --- Version check: happy path ---
 
 @test "version check passes when both packages match pinned versions" {
-  mock_all "0.13.2" "0.13.2"
+  mock_all "0.14.0" "0.14.0"
   run_script
   [ "$status" -eq 0 ]
 }
@@ -62,40 +62,40 @@ run_script() {
 # --- Version check: abort paths ---
 
 @test "version check aborts when json2yamlresume is behind latest" {
-  mock_npm "0.14.0" "0.13.2"
+  mock_npm "0.15.0" "0.13.2"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"json2yamlresume is pinned at 0.13.2 but 0.14.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
 }
 
 @test "version check aborts when yamlresume is behind latest" {
-  mock_npm "0.13.2" "0.14.0"
+  mock_npm "0.14.0" "0.15.0"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"yamlresume is pinned at 0.13.2 but 0.14.0 is available"* ]]
+  [[ "$output" == *"yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_YR_VERSION"* ]]
 }
 
 @test "version check aborts when both packages are behind latest" {
-  mock_npm "0.14.0" "0.14.0"
+  mock_npm "0.15.0" "0.15.0"
   run_script
   [ "$status" -eq 1 ]
   # Should fail on the first check (json2yamlresume) and never reach yamlresume
-  [[ "$output" == *"json2yamlresume is pinned at 0.13.2 but 0.14.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
 }
 
 # --- Version check: offline fallback ---
 
 @test "version check continues when json2yamlresume npm query fails" {
-  mock_npm "fail" "0.13.2"
+  mock_npm "fail" "0.14.0"
   mock_docker
   run_script
   [ "$status" -eq 0 ]
 }
 
 @test "version check continues when yamlresume npm query fails" {
-  mock_npm "0.13.2" "fail"
+  mock_npm "0.14.0" "fail"
   mock_docker
   run_script
   [ "$status" -eq 0 ]

--- a/tests/sync-resume.bats
+++ b/tests/sync-resume.bats
@@ -62,11 +62,12 @@ run_script() {
 # --- Version check: abort paths ---
 
 @test "version check aborts when json2yamlresume is behind latest" {
-  mock_npm "0.15.0" "0.13.2"
+  mock_npm "0.15.0" "0.14.0"
   run_script
   [ "$status" -eq 1 ]
   [[ "$output" == *"json2yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
+  [[ "$output" != *"ERROR: yamlresume is pinned at"* ]]
 }
 
 @test "version check aborts when yamlresume is behind latest" {
@@ -83,6 +84,7 @@ run_script() {
   [ "$status" -eq 1 ]
   # Should fail on the first check (json2yamlresume) and never reach yamlresume
   [[ "$output" == *"json2yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
+  [[ "$output" != *"ERROR: yamlresume is pinned at"* ]]
 }
 
 # --- Version check: offline fallback ---


### PR DESCRIPTION
## Summary

Bumps json2yamlresume and yamlresume pinned versions from 0.13.2 to 0.14.0, regenerates resume-full.html to pick up the calm-template vertical-stacking fix, and adds a make sync-resume target for local regeneration.

## Changes

- Pinned json2yamlresume and yamlresume versions bumped from 0.13.2 to 0.14.0 (via scripts/sync-resume.sh), unblocking resume regeneration on push to main
- Resume skills and languages now stack vertically by default instead of horizontally, matching the calm-template fix in yamlresume v0.14.0
- Version-check test fixtures updated to match the new pins (via tests/sync-resume.bats)
- New make sync-resume target added for running the sync script locally

## Test Plan

- [ ] All 81 existing tests pass
- [ ] Manual: ran make sync-resume, confirmed both tools resolve at 0.14.0 and output generates cleanly

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/160

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to extract a LinkedIn resume and synchronize resume data.
* **Updates**
  * Resume synchronization now uses updated package versions for improved compatibility.
* **Tests**
  * Expanded validation for version checks, upgrade scenarios, error handling, and offline fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->