### PR TITLE
[issues/108] CI gate for social banner freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,19 @@ jobs:
       - name: Check resume tool versions
         run: ./scripts/check-resume-tool-versions.sh
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+
       - name: Check resume freshness
         uses: couimet/github-actions/check-generated-drift@main
         with:
           command: SKIP_VERSION_CHECK=true make sync-resume && git checkout -- resume-full.html
           github-token: ${{ secrets.GITHUB_TOKEN }}
           header: 'Resume generated drift check'
+
+      - name: Check banner freshness
+        uses: couimet/github-actions/check-generated-drift@main
+        with:
+          command: (cd scripts/social-banner && uv sync --frozen) && UV_FROZEN=1 make banner
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          header: 'Social banner generated drift check'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
       - name: Check resume freshness
         uses: couimet/github-actions/check-generated-drift@main
         with:
-          command: SKIP_VERSION_CHECK=true make sync-resume && git checkout -- resume-full.html
+          command: SKIP_VERSION_CHECK=true make sync-resume
+          post-generate: git checkout -- resume-full.html
           github-token: ${{ secrets.GITHUB_TOKEN }}
           header: 'Resume generated drift check'
 
@@ -181,5 +182,6 @@ jobs:
         uses: couimet/github-actions/check-generated-drift@main
         with:
           command: (cd scripts/social-banner && uv sync --frozen) && UV_FROZEN=1 make banner
+          post-generate: cd scripts/social-banner && UV_FROZEN=1 uv run python check_banner_drift.py
           github-token: ${{ secrets.GITHUB_TOKEN }}
           header: 'Social banner generated drift check'

--- a/scripts/social-banner/check_banner_drift.py
+++ b/scripts/social-banner/check_banner_drift.py
@@ -1,0 +1,79 @@
+"""Normalize cross-platform JPEG encoder drift in generated social banners.
+
+Banner JPEGs are committed to the repo but generated with Pillow on the
+developer's machine (macOS). CI regenerates them on Linux, and the two
+JPEG encoders emit different bytes for the same pixels, so the repo-root
+`check-generated` CI job would see false drift on every run.
+
+Runs as that job's post-generate hook, after `make banner` and before the
+git drift check.
+"""
+
+import io
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageStat
+from settings import GOLDEN_RMS_THRESHOLD
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+    return result.stdout
+
+
+def repo_root() -> Path:
+    return Path(git(Path.cwd(), "rev-parse", "--show-toplevel").strip())
+
+
+def head_bytes(repo: Path, relpath: str) -> bytes | None:
+    """Committed bytes of relpath, or None when HEAD has no such file."""
+    result = subprocess.run(
+        ["git", "show", f"HEAD:{relpath}"], cwd=repo, capture_output=True, check=False
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def pixels_match(working: bytes, committed: bytes) -> bool:
+    """True when both JPEGs decode to the same RGB pixels within tolerance."""
+    with (
+        Image.open(io.BytesIO(working)) as working_im,
+        Image.open(io.BytesIO(committed)) as committed_im,
+    ):
+        if working_im.size != committed_im.size:
+            return False
+        diff = ImageChops.difference(
+            working_im.convert("RGB"), committed_im.convert("RGB")
+        )
+        rms_per_channel = ImageStat.Stat(diff).rms
+        return all(channel <= GOLDEN_RMS_THRESHOLD for channel in rms_per_channel)
+
+
+def main() -> int:
+    repo = repo_root()
+    for path in sorted((repo / "img").glob("social-banner*.jpg")):
+        relpath = path.relative_to(repo).as_posix()
+        committed = head_bytes(repo, relpath)
+        if committed is None:
+            print(f"left as-is (not in HEAD): {relpath}")
+            continue
+        try:
+            match = pixels_match(path.read_bytes(), committed)
+        except (OSError, ValueError):
+            # An undecodable file means real drift; leave it for git to flag.
+            match = False
+        if match:
+            git(repo, "checkout", "--", relpath)
+            print(f"reverted (pixels match HEAD): {relpath}")
+        else:
+            print(f"left as-is (pixels differ from HEAD): {relpath}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/social-banner/settings.py
+++ b/scripts/social-banner/settings.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 """Shared settings for social banner generation scripts.
 
-Both generate.py and generate_rangelink.py import this module so colours,
-fonts, layout, and watermark stay in sync.
+Generation scripts and drift comparisons import this module so colours,
+fonts, layout, watermark, and tolerances stay in sync.
 """
 
 # ── Dimensions ──────────────────────────────────────────────────────────────
@@ -61,3 +61,11 @@ WATERMARK_MARGIN = 30            # px from bottom-right corner
 # ── Output ──────────────────────────────────────────────────────────────────
 
 JPG_QUALITY = 92
+
+# ── Drift comparison ────────────────────────────────────────────────────────
+
+# RMS-per-channel tolerance between generated and committed banner pixels.
+# Shared by the golden-image tests (tests/conftest.py) and the CI drift
+# normalization (check_banner_drift.py). Encoder choices shift decoded
+# pixels slightly; real content changes are orders of magnitude larger.
+GOLDEN_RMS_THRESHOLD = 10.0

--- a/scripts/social-banner/tests/conftest.py
+++ b/scripts/social-banner/tests/conftest.py
@@ -3,12 +3,13 @@ import shutil
 from pathlib import Path
 
 from PIL import Image, ImageChops, ImageStat
+from settings import GOLDEN_RMS_THRESHOLD
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 GOLDEN_DIR = Path(__file__).parent / "golden"
 
 
-def assert_matches_golden(actual_path, golden_path, threshold=10.0):
+def assert_matches_golden(actual_path, golden_path, threshold=GOLDEN_RMS_THRESHOLD):
     # UPDATE_GOLDEN=1 promotes the actual output to the new golden. Used when
     # the banner design intentionally changes; never set in CI.
     if os.environ.get("UPDATE_GOLDEN"):

--- a/tests/check_banner_drift.bats
+++ b/tests/check_banner_drift.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/social-banner/check_banner_drift.py
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+  CHECK_SCRIPT="$REPO_ROOT/scripts/social-banner/check_banner_drift.py"
+  PYTHON="uv run --project $REPO_ROOT python"
+
+  WORK="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$WORK/img"
+  cd "$WORK"
+  git init -q
+  git config user.email "bats@example.com"
+  git config user.name "BATS"
+  git config commit.gpgsign false
+}
+
+# --- Helpers ---
+
+# Write an 8x8 JPEG. "baseline" and "progressive" encode the same pixels to
+# different bytes, mimicking the macOS-vs-Linux encoder drift seen in CI.
+make_jpeg() {
+  local path="$1" mode="$2" colour="$3"
+  $PYTHON - "$path" "$mode" "$colour" <<'PYEOF'
+import sys
+from PIL import Image
+
+path, mode, colour = sys.argv[1:4]
+Image.new("RGB", (8, 8), colour).save(
+    path, "JPEG", quality=92, progressive=(mode == "progressive")
+)
+PYEOF
+}
+
+commit_banner() {
+  make_jpeg "img/social-banner.jpg" baseline red
+  git add img
+  git commit -qm "add banner"
+}
+
+run_check() {
+  run $PYTHON "$CHECK_SCRIPT"
+}
+
+# --- Tests ---
+
+@test "reverts a banner with identical pixels despite byte drift" {
+  commit_banner
+  make_jpeg "img/social-banner.jpg" progressive red
+
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reverted (pixels match HEAD): img/social-banner.jpg"* ]]
+  [ -z "$(git status --porcelain img/)" ]
+}
+
+@test "reverts a banner whose pixels differ only within tolerance" {
+  commit_banner
+  # One pixel off by 1 in one channel — far below the RMS threshold.
+  $PYTHON - "img/social-banner.jpg" <<'PYEOF'
+import sys
+from PIL import Image
+
+path = sys.argv[1]
+im = Image.open(path)
+im.putpixel((0, 0), (254, 0, 0))
+im.save(path, "JPEG", quality=92)
+PYEOF
+
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reverted (pixels match HEAD): img/social-banner.jpg"* ]]
+  [ -z "$(git status --porcelain img/)" ]
+}
+
+@test "leaves a banner with genuinely different pixels in place" {
+  commit_banner
+  make_jpeg "img/social-banner.jpg" baseline blue
+
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"left as-is (pixels differ from HEAD): img/social-banner.jpg"* ]]
+  [[ "$(git status --porcelain img/)" == *" M img/social-banner.jpg"* ]]
+}
+
+@test "reverts drifted banners while real drift stays flagged" {
+  make_jpeg "img/social-banner.jpg" baseline red
+  make_jpeg "img/social-banner-rangelink.jpg" baseline red
+  git add img
+  git commit -qm "add banners"
+
+  make_jpeg "img/social-banner.jpg" progressive red
+  make_jpeg "img/social-banner-rangelink.jpg" baseline blue
+
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reverted (pixels match HEAD): img/social-banner.jpg"* ]]
+  [[ "$output" == *"left as-is (pixels differ from HEAD): img/social-banner-rangelink.jpg"* ]]
+  [[ "$(git status --porcelain img/)" == *" M img/social-banner-rangelink.jpg"* ]]
+  [[ "$(git status --porcelain img/)" != *"social-banner.jpg"* ]]
+}
+
+@test "leaves untracked banners alone" {
+  commit_banner
+  make_jpeg "img/social-banner-extra.jpg" baseline green
+
+  run_check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"left as-is (not in HEAD): img/social-banner-extra.jpg"* ]]
+  [[ "$(git status --porcelain img/)" == *"?? img/social-banner-extra.jpg"* ]]
+}


### PR DESCRIPTION
## Summary

The CI `check-generated` job now also verifies that all four social banner images are fresh. When source data changes without a matching `make banner` run, the build fails and a PR comment explains which images are stale.

## Changes

- New `Check banner freshness` step in the `check-generated` CI job regenerates all social banners via `make banner` and fails if any output differs from the committed image
- The `check-generated` job now installs `uv` (required by the banner generation scripts under `scripts/social-banner/`)
- Uses the same `check-generated-drift` action that already gates resume freshness, keeping the pattern consistent

## Test Plan

- [ ] All existing tests pass
- [ ] Manual testing: modifying `_data/bio.json` then running `make banner` produces a dirty `git diff` on `img/social-banner.jpg`; reverting the edit and regenerating restores cleanliness

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/108

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated quality checks for generated assets.
  * Added validation to ensure social banners remain up to date.
  * Checks now distinguish harmless image-encoding differences from meaningful visual changes.
  * Detected visual differences remain visible in the build process, helping identify outdated generated content before release.
  * Added coverage for banner consistency across multiple files and untracked assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->