### PR TITLE
[issues/172] Add Network Nudge French support promotion

### DIFF
--- a/_data/promotions.yml
+++ b/_data/promotions.yml
@@ -5,6 +5,32 @@
 # context: free-form text — a link, description, or project reference.
 # Channels are keyed by name (linkedin, x, etc.), each with url and content.
 
+- date: "2026-08-11"
+  context: https://ouimet.info/projects/network-nudge/
+  projects:
+    - network-nudge
+  summary: "Support for French / Ajout du français"
+  linkedin:
+    url: https://www.linkedin.com/feed/update/urn:li:share:7493003528911708160/
+    content: |
+      Network Nudge parle maintenant français ⚜️
+
+      Je voulais que l'outil fonctionne aussi bien en français qu'en anglais. Basculer entre les langues nécessite uniquement un clic sur un bouton.
+
+      English version: Network Nudge now supports French.
+
+      👉 https://ouimet.info/projects/network-nudge/
+  x:
+    url: https://x.com/charlesouimet/status/2087238514781925615
+    content: |
+      Network Nudge parle français ⚜️
+
+      Basculer entre les langues nécessite uniquement un clic sur un bouton.
+
+      English version: Network Nudge now supports French.
+
+      👉 https://ouimet.info/projects/network-nudge/
+
 - date: "2026-07-30"
   context: https://open-vsx.org/extension/couimet/rangelink-vscode-extension
   projects:


### PR DESCRIPTION
Adds a social media promotion entry announcing Network Nudge's French i18n support. Both LinkedIn and X posts are written in French first with a short English line noting the new capability. Follows the same pattern as the RangeLink 1.2K promotion (PR #156).

- Network Nudge project page now surfaces a French-support announcement in its Featured In section, with French-first post content on LinkedIn and X

- [x] Schema validation passes (`_data/promotions.schema.json`)
- [x] All existing tests pass (83 tests, 9 files)

Closes https://github.com/couimet/couimet.github.io/issues/172

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an August 11, 2026 promotion highlighting Network Nudge’s French-language support.
  * Included promotional content and links for LinkedIn and X.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->