### PR TITLE
[issues/174] Update `yamlresume` pinned versions to `0.14.2`

### DIFF
--- a/scripts/sync-resume.sh
+++ b/scripts/sync-resume.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PINNED_J2Y_VERSION="0.14.0"
-PINNED_YR_VERSION="0.14.0"
+PINNED_J2Y_VERSION="0.14.2"
+PINNED_YR_VERSION="0.14.2"
 
 if [ "${SKIP_VERSION_CHECK:-}" = "true" ]; then
   echo "==> Skipping version check (SKIP_VERSION_CHECK=true)"

--- a/tests/sync-resume.bats
+++ b/tests/sync-resume.bats
@@ -43,7 +43,7 @@ EOF
 
 # Full mocks: both npm and docker stubbed.
 mock_all() {
-  mock_npm "${1:-0.14.0}" "${2:-0.14.0}"
+  mock_npm "${1:-0.14.2}" "${2:-0.14.2}"
   mock_docker
 }
 
@@ -54,7 +54,7 @@ run_script() {
 # --- Version check: happy path ---
 
 @test "version check passes when both packages match pinned versions" {
-  mock_all "0.14.0" "0.14.0"
+  mock_all "0.14.2" "0.14.2"
   run_script
   [ "$status" -eq 0 ]
 }
@@ -62,19 +62,19 @@ run_script() {
 # --- Version check: abort paths ---
 
 @test "version check aborts when json2yamlresume is behind latest" {
-  mock_npm "0.15.0" "0.14.0"
+  mock_npm "0.15.0" "0.14.2"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"json2yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
   [[ "$output" != *"ERROR: yamlresume is pinned at"* ]]
 }
 
 @test "version check aborts when yamlresume is behind latest" {
-  mock_npm "0.14.0" "0.15.0"
+  mock_npm "0.14.2" "0.15.0"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
+  [[ "$output" == *"yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_YR_VERSION"* ]]
 }
 
@@ -83,21 +83,21 @@ run_script() {
   run_script
   [ "$status" -eq 1 ]
   # Should fail on the first check (json2yamlresume) and never reach yamlresume
-  [[ "$output" == *"json2yamlresume is pinned at 0.14.0 but 0.15.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
   [[ "$output" != *"ERROR: yamlresume is pinned at"* ]]
 }
 
 # --- Version check: offline fallback ---
 
 @test "version check continues when json2yamlresume npm query fails" {
-  mock_npm "fail" "0.14.0"
+  mock_npm "fail" "0.14.2"
   mock_docker
   run_script
   [ "$status" -eq 0 ]
 }
 
 @test "version check continues when yamlresume npm query fails" {
-  mock_npm "0.14.0" "fail"
+  mock_npm "0.14.2" "fail"
   mock_docker
   run_script
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Bumps the pinned versions of `json2yamlresume` and `yamlresume` from 0.14.0 to 0.14.2 to unblock the CI sync-resume workflow, which aborts when newer npm versions are available.

## Changes

- Pinned `json2yamlresume` and `yamlresume` versions bumped from 0.14.0 to 0.14.2 (via `scripts/sync-resume.sh`), unblocking resume regeneration on push to main
- Version-check test fixtures updated to match the new pins (via `tests/sync-resume.bats`)

## Test Plan

- [ ] All 104 existing tests pass
- [ ] Manual: ran `make sync-resume`, confirmed both tools resolve at 0.14.2 and output generates cleanly

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/174

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore