### PR TITLE
[issues/175] Add CI check to detect stale `yamlresume` pins on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Check resume tool versions
+        run: ./scripts/check-resume-tool-versions.sh
+
       - name: Check resume freshness
         uses: couimet/github-actions/check-generated-drift@main
         with:

--- a/scripts/check-resume-tool-versions.sh
+++ b/scripts/check-resume-tool-versions.sh
@@ -15,8 +15,7 @@ PINNED_YR_VERSION=$(sed -n 's/^PINNED_YR_VERSION="\([^"]*\)".*/\1/p' "$SYNC_SCRI
 
 echo "==> Checking for newer tool versions..."
 
-LATEST_J2Y=$(npm view json2yamlresume version 2>/dev/null || echo "unknown")
-LATEST_YR=$(npm view yamlresume version 2>/dev/null || echo "unknown")
+LATEST_J2Y=$(npm --fetch-retries=0 --fetch-timeout=10000 view json2yamlresume version 2>/dev/null || echo "unknown")
 
 if [ "$LATEST_J2Y" != "unknown" ] && [ "$LATEST_J2Y" != "$PINNED_J2Y_VERSION" ]; then
   echo "ERROR: json2yamlresume is pinned at $PINNED_J2Y_VERSION but $LATEST_J2Y is available."
@@ -24,6 +23,8 @@ if [ "$LATEST_J2Y" != "unknown" ] && [ "$LATEST_J2Y" != "$PINNED_J2Y_VERSION" ];
   echo "  https://www.npmjs.com/package/json2yamlresume"
   exit 1
 fi
+
+LATEST_YR=$(npm --fetch-retries=0 --fetch-timeout=10000 view yamlresume version 2>/dev/null || echo "unknown")
 
 if [ "$LATEST_YR" != "unknown" ] && [ "$LATEST_YR" != "$PINNED_YR_VERSION" ]; then
   echo "ERROR: yamlresume is pinned at $PINNED_YR_VERSION but $LATEST_YR is available."

--- a/scripts/check-resume-tool-versions.sh
+++ b/scripts/check-resume-tool-versions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check whether pinned json2yamlresume / yamlresume versions in scripts/sync-resume.sh
+# are still current on npm. Exits 1 when a newer version is available so CI can catch
+# stale pins on PRs before they block post-merge deploys.
+#
+# npm unreachable → exit 0 (graceful fallback, not a hard block)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC_SCRIPT="$SCRIPT_DIR/sync-resume.sh"
+
+PINNED_J2Y_VERSION=$(sed -n 's/^PINNED_J2Y_VERSION="\([^"]*\)".*/\1/p' "$SYNC_SCRIPT")
+PINNED_YR_VERSION=$(sed -n 's/^PINNED_YR_VERSION="\([^"]*\)".*/\1/p' "$SYNC_SCRIPT")
+
+echo "==> Checking for newer tool versions..."
+
+LATEST_J2Y=$(npm view json2yamlresume version 2>/dev/null || echo "unknown")
+LATEST_YR=$(npm view yamlresume version 2>/dev/null || echo "unknown")
+
+if [ "$LATEST_J2Y" != "unknown" ] && [ "$LATEST_J2Y" != "$PINNED_J2Y_VERSION" ]; then
+  echo "ERROR: json2yamlresume is pinned at $PINNED_J2Y_VERSION but $LATEST_J2Y is available."
+  echo "Update PINNED_J2Y_VERSION in scripts/sync-resume.sh after verifying compatibility:"
+  echo "  https://www.npmjs.com/package/json2yamlresume"
+  exit 1
+fi
+
+if [ "$LATEST_YR" != "unknown" ] && [ "$LATEST_YR" != "$PINNED_YR_VERSION" ]; then
+  echo "ERROR: yamlresume is pinned at $PINNED_YR_VERSION but $LATEST_YR is available."
+  echo "Update PINNED_YR_VERSION in scripts/sync-resume.sh after verifying compatibility:"
+  echo "  https://www.npmjs.com/package/yamlresume"
+  exit 1
+fi
+
+echo "  → json2yamlresume pinned at $PINNED_J2Y_VERSION, latest is $LATEST_J2Y"
+echo "  → yamlresume pinned at $PINNED_YR_VERSION, latest is $LATEST_YR"

--- a/scripts/sync-resume.sh
+++ b/scripts/sync-resume.sh
@@ -13,24 +13,7 @@ PINNED_YR_VERSION="0.14.2"
 if [ "${SKIP_VERSION_CHECK:-}" = "true" ]; then
   echo "==> Skipping version check (SKIP_VERSION_CHECK=true)"
 else
-  echo "==> Checking for newer tool versions..."
-
-  LATEST_J2Y=$(npm view json2yamlresume version 2>/dev/null || echo "unknown")
-  LATEST_YR=$(npm view yamlresume version 2>/dev/null || echo "unknown")
-
-  if [ "$LATEST_J2Y" != "unknown" ] && [ "$LATEST_J2Y" != "$PINNED_J2Y_VERSION" ]; then
-    echo "ERROR: json2yamlresume is pinned at $PINNED_J2Y_VERSION but $LATEST_J2Y is available."
-    echo "Update PINNED_J2Y_VERSION in scripts/sync-resume.sh after verifying compatibility:"
-    echo "  https://www.npmjs.com/package/json2yamlresume"
-    exit 1
-  fi
-
-  if [ "$LATEST_YR" != "unknown" ] && [ "$LATEST_YR" != "$PINNED_YR_VERSION" ]; then
-    echo "ERROR: yamlresume is pinned at $PINNED_YR_VERSION but $LATEST_YR is available."
-    echo "Update PINNED_YR_VERSION in scripts/sync-resume.sh after verifying compatibility:"
-    echo "  https://www.npmjs.com/package/yamlresume"
-    exit 1
-  fi
+  "$SCRIPT_DIR/check-resume-tool-versions.sh"
 fi
 
 echo "==> Converting resume.json → resume.yml (json2yamlresume)"

--- a/tests/check-resume-tool-versions.bats
+++ b/tests/check-resume-tool-versions.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+
+# Tests for scripts/check-resume-tool-versions.sh
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_DIRNAME")" && pwd)"
+  CHECK_SCRIPT="$REPO_ROOT/scripts/check-resume-tool-versions.sh"
+  MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
+  mkdir -p "$MOCK_DIR"
+}
+
+# --- Helpers ---
+
+# Create a mock npm that echoes the given versions for json2yamlresume and yamlresume.
+# Pass "fail" as a version to make npm exit 1 (simulating offline / registry down).
+mock_npm() {
+  local j2y="$1" yr="$2"
+  cat > "$MOCK_DIR/npm" << EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *json2yamlresume*)
+    [ "$j2y" = "fail" ] && exit 1
+    echo "$j2y"
+    ;;
+  *yamlresume*)
+    [ "$yr" = "fail" ] && exit 1
+    echo "$yr"
+    ;;
+  *) exit 1 ;;
+esac
+EOF
+  chmod +x "$MOCK_DIR/npm"
+}
+
+run_check_script() {
+  run env PATH="$MOCK_DIR:$PATH" bash "$CHECK_SCRIPT"
+}
+
+# --- Happy path ---
+
+@test "succeeds when both versions match" {
+  mock_npm "0.14.2" "0.14.2"
+  run_check_script
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pinned at 0.14.2, latest is 0.14.2"* ]]
+}
+
+# --- Abort paths ---
+
+@test "fails when json2yamlresume is behind" {
+  mock_npm "0.15.0" "0.14.2"
+  run_check_script
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ERROR: json2yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
+}
+
+@test "fails when yamlresume is behind" {
+  mock_npm "0.14.2" "0.15.0"
+  run_check_script
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ERROR: yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"Update PINNED_YR_VERSION"* ]]
+}
+
+@test "fails on first mismatch when both are behind (short-circuit)" {
+  mock_npm "0.15.0" "0.15.0"
+  run_check_script
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ERROR: json2yamlresume"* ]]
+  [[ "$output" != *"ERROR: yamlresume"* ]]
+}
+
+# --- Offline fallback ---
+
+@test "succeeds when json2yamlresume npm query fails" {
+  mock_npm "fail" "0.14.2"
+  run_check_script
+  [ "$status" -eq 0 ]
+}
+
+@test "succeeds when yamlresume npm query fails" {
+  mock_npm "0.14.2" "fail"
+  run_check_script
+  [ "$status" -eq 0 ]
+}
+
+@test "succeeds when both npm queries fail" {
+  mock_npm "fail" "fail"
+  run_check_script
+  [ "$status" -eq 0 ]
+}

--- a/tests/check-resume-tool-versions.bats
+++ b/tests/check-resume-tool-versions.bats
@@ -13,10 +13,13 @@ setup() {
 
 # Create a mock npm that echoes the given versions for json2yamlresume and yamlresume.
 # Pass "fail" as a version to make npm exit 1 (simulating offline / registry down).
+# Each invocation is logged to $MOCK_DIR/npm-calls.log so tests can assert which
+# npm commands were (or were not) called.
 mock_npm() {
   local j2y="$1" yr="$2"
   cat > "$MOCK_DIR/npm" << EOF
 #!/usr/bin/env bash
+echo "\$*" >> "$MOCK_DIR/npm-calls.log"
 case "\$*" in
   *json2yamlresume*)
     [ "$j2y" = "fail" ] && exit 1
@@ -69,6 +72,12 @@ run_check_script() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"ERROR: json2yamlresume"* ]]
   [[ "$output" != *"ERROR: yamlresume"* ]]
+  # Assert only one npm call was made (json2yamlresume short-circuits before yamlresume).
+  # "yamlresume" is a substring of "json2yamlresume", so match the package name with a
+  # leading space to avoid false positives.
+  run cat "$MOCK_DIR/npm-calls.log"
+  [[ "$output" == *" json2yamlresume"* ]]
+  [[ "$output" != *" yamlresume "* ]]
 }
 
 # --- Offline fallback ---


### PR DESCRIPTION
## Summary

Extracts the yamlresume version check from `scripts/sync-resume.sh` into a standalone script and adds it to the `check-generated` CI job so stale npm pins are caught on PRs before they block post-merge deploys.

## Changes

- New `scripts/check-resume-tool-versions.sh` script runs the version check independently, reading pinned versions from `sync-resume.sh` and comparing against npm. Exits 0 when npm is unreachable to avoid flaky CI blocks
- `scripts/sync-resume.sh` delegates to the new script instead of inlining the version check, gated by the existing `SKIP_VERSION_CHECK` env var
- `check-generated` CI job gains a `Check resume tool versions` step that calls the new script on every PR, catching mismatches before merge
- 7 unit tests in a new `tests/check-resume-tool-versions.bats` covering all branches: both-match, j2y-behind, yr-behind, short-circuit, and the three npm-unreachable fallbacks

## Test Plan

- [ ] All 111 existing tests pass (58 Python + 53 bats)
- [ ] Manual: ran `./scripts/check-resume-tool-versions.sh` locally, confirmed it detects the current 0.14.2 pins as matching

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/175

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated CI checks to identify outdated pinned resume-tool versions.
  * Resume synchronization now uses a shared version-validation process.
  * Version checks tolerate temporary package registry unavailability while still detecting outdated versions when current information is available.
* **Tests**
  * Added coverage for matching versions, version mismatches, and offline scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->