### PR TITLE
[issues/180] Update resume and Career ChangeLog for `Procurify`

### DIFF
--- a/_includes/career/changelog.html
+++ b/_includes/career/changelog.html
@@ -28,6 +28,15 @@
       <p>All notable changes to this project (my career) will be documented in this section.</p>
       <p>The format is based on <a href="https://keepachangelog.com/en/1.1.0/" target="_blank" rel="noopener noreferrer">Keep a Changelog</a> and this project
         adheres to <a href="https://semver.org/spec/v2.0.0.html" target="_blank" rel="noopener noreferrer">Semantic Versioning</a>.</p>
+      <h2 id="changelog-9-0-0"><a href="#changelog-9-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>9.0.0 - Staff Backend Software Developer @ Procurify (2026 to Present)</h2>
+      <h3 id="changelog-9-0-0-added"><a href="#changelog-9-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
+      <ul>
+        <li>Member of the Platform team at <a href="https://www.procurify.com/" target="_blank" rel="noopener noreferrer">Procurify</a>.</li>
+      </ul>
+      <h3 id="changelog-9-0-0-deprecated"><a href="#changelog-9-0-0-deprecated" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Deprecated</h3>
+      <ul>
+        <li>The Shopify role concluded in 2026-04, and the journey continued on the Platform team at Procurify.</li>
+      </ul>
       <h2 id="changelog-8-0-0"><a href="#changelog-8-0-0" class="heading-anchor" aria-label="Copy link to this section">🔗</a>8.0.0 - Staff Software Developer @ Shopify (2025 to 2026)</h2>
       <h3 id="changelog-8-0-0-added"><a href="#changelog-8-0-0-added" class="heading-anchor" aria-label="Copy link to this section">🔗</a>Added</h3>
       <ul>

--- a/resume.json
+++ b/resume.json
@@ -53,11 +53,18 @@
   },
   "work": [
     {
+      "name": "Procurify",
+      "position": "Staff Backend Software Developer",
+      "url": "https://www.procurify.com/",
+      "startDate": "2026-08-24",
+      "summary": "Member of the Platform team at Procurify, a procure-to-pay and spend management platform."
+    },
+    {
       "name": "Shopify",
       "position": "Staff Developer",
       "url": "https://shopify.com",
-      "startDate": "2025-08-01",
-      "endDate": "2026-05-01",
+      "startDate": "2025-08-25",
+      "endDate": "2026-04-24",
       "summary": "Member of the shop.app Buyer Acquisition (growth) team, focused on the Shop Cash domain. Designed an affiliate payout program in the AdTech/growth space and contributed to the shop.app ecosystem migration to distributed SQL.",
       "highlights": [
         "Owned the migration of one of the highest-QPS tables (top 20) to YugabyteDB as part of the shop.app ecosystem transition to distributed SQL.",

--- a/resume.yml
+++ b/resume.yml
@@ -258,11 +258,17 @@ content:
       summary: Chaired CIP4's preflight sub-committee, contributing to industry
         standards for print workflow automation and quality control.
   work:
+    - name: Procurify
+      position: Staff Backend Software Developer
+      url: https://www.procurify.com/
+      startDate: 2026-08-24
+      summary: Member of the Platform team at Procurify, a procure-to-pay and spend
+        management platform.
     - name: Shopify
       position: Staff Developer
       url: https://shopify.com
-      startDate: 2025-08-01
-      endDate: 2026-05-01
+      startDate: 2025-08-25
+      endDate: 2026-04-24
       summary: >-
         Member of the shop.app Buyer Acquisition (growth) team, focused on the
         Shop Cash domain. Designed an affiliate payout program in the


### PR DESCRIPTION
## Summary

Adds the upcoming Procurify role to the Career Changelog and resume.json. Charles starts on 2026-08-24 as Staff Backend Software Developer on the Platform team; the changelog gains a 9.0.0 section and the resume gains a matching work entry as the current role.

## Changes

- Career Changelog gains a 9.0.0 section above 8.0.0 with an Added bullet for Platform team membership and a Deprecated bullet stating the Shopify role concluded in 2026-04, with the journey continuing at Procurify (via `_includes/career/changelog.html`)
- resume.json gains the Procurify work entry: Staff Backend Software Developer, startDate 2026-08-24, no endDate, summary-only with no highlights until the role produces accomplishments; the Shopify entry endDate is corrected from 2026-05-01 to 2026-04-24

## Test Plan

- [ ] All existing tests pass (`make test`: Python unittests and 111 BATS tests)
- [ ] `make lint` passes (Jekyll build, htmlproofer, ruff, network-nudge lint/format)
- [ ] Manual: the built `_site/index.html` renders the 9.0.0 heading; `resume.json` parses as valid JSON
- [ ] New tests added for: none (content-only change, no logic to test)

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/180

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

@coderabbitai ignore