### PR TITLE
[issues/182] Externalize `yamlresume` pins and bump to `0.14.3`

### DIFF
--- a/resume-tools.versions
+++ b/resume-tools.versions
@@ -1,0 +1,6 @@
+# Pinned npm tool versions for the resume pipeline. Single source of truth for
+# scripts/sync-resume.sh and scripts/check-resume-tool-versions.sh; tests build
+# their fixtures from this file too. Bump here when npm publishes newer versions:
+# scripts/check-resume-tool-versions.sh fails in CI while the pins are stale.
+PINNED_J2Y_VERSION="0.14.3"
+PINNED_YR_VERSION="0.14.3"

--- a/scripts/check-resume-tool-versions.sh
+++ b/scripts/check-resume-tool-versions.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Check whether pinned json2yamlresume / yamlresume versions in scripts/sync-resume.sh
-# are still current on npm. Exits 1 when a newer version is available so CI can catch
-# stale pins on PRs before they block post-merge deploys.
+# Check whether the pinned json2yamlresume / yamlresume versions in
+# resume-tools.versions are still current on npm. Exits 1 when a newer version is
+# available so CI can catch stale pins on PRs before they block post-merge deploys.
 #
 # npm unreachable → exit 0 (graceful fallback, not a hard block)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SYNC_SCRIPT="$SCRIPT_DIR/sync-resume.sh"
 
-PINNED_J2Y_VERSION=$(sed -n 's/^PINNED_J2Y_VERSION="\([^"]*\)".*/\1/p' "$SYNC_SCRIPT")
-PINNED_YR_VERSION=$(sed -n 's/^PINNED_YR_VERSION="\([^"]*\)".*/\1/p' "$SYNC_SCRIPT")
+# Pinned versions come from the same file sync-resume.sh sources.
+source "$SCRIPT_DIR/../resume-tools.versions"
 
 echo "==> Checking for newer tool versions..."
 
@@ -19,7 +18,7 @@ LATEST_J2Y=$(npm --fetch-retries=0 --fetch-timeout=10000 view json2yamlresume ve
 
 if [ "$LATEST_J2Y" != "unknown" ] && [ "$LATEST_J2Y" != "$PINNED_J2Y_VERSION" ]; then
   echo "ERROR: json2yamlresume is pinned at $PINNED_J2Y_VERSION but $LATEST_J2Y is available."
-  echo "Update PINNED_J2Y_VERSION in scripts/sync-resume.sh after verifying compatibility:"
+  echo "Update PINNED_J2Y_VERSION in resume-tools.versions after verifying compatibility:"
   echo "  https://www.npmjs.com/package/json2yamlresume"
   exit 1
 fi
@@ -28,7 +27,7 @@ LATEST_YR=$(npm --fetch-retries=0 --fetch-timeout=10000 view yamlresume version 
 
 if [ "$LATEST_YR" != "unknown" ] && [ "$LATEST_YR" != "$PINNED_YR_VERSION" ]; then
   echo "ERROR: yamlresume is pinned at $PINNED_YR_VERSION but $LATEST_YR is available."
-  echo "Update PINNED_YR_VERSION in scripts/sync-resume.sh after verifying compatibility:"
+  echo "Update PINNED_YR_VERSION in resume-tools.versions after verifying compatibility:"
   echo "  https://www.npmjs.com/package/yamlresume"
   exit 1
 fi

--- a/scripts/sync-resume.sh
+++ b/scripts/sync-resume.sh
@@ -7,8 +7,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PINNED_J2Y_VERSION="0.14.2"
-PINNED_YR_VERSION="0.14.2"
+# Pinned tool versions live in resume-tools.versions (repo root) so version
+# bumps don't churn this file.
+source "$REPO_ROOT/resume-tools.versions"
 
 if [ "${SKIP_VERSION_CHECK:-}" = "true" ]; then
   echo "==> Skipping version check (SKIP_VERSION_CHECK=true)"

--- a/tests/check-resume-tool-versions.bats
+++ b/tests/check-resume-tool-versions.bats
@@ -7,6 +7,8 @@ setup() {
   CHECK_SCRIPT="$REPO_ROOT/scripts/check-resume-tool-versions.sh"
   MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
   mkdir -p "$MOCK_DIR"
+  # Pinned versions come from the same file the script under test sources.
+  source "$REPO_ROOT/resume-tools.versions"
 }
 
 # --- Helpers ---
@@ -42,27 +44,27 @@ run_check_script() {
 # --- Happy path ---
 
 @test "succeeds when both versions match" {
-  mock_npm "0.14.2" "0.14.2"
+  mock_npm "$PINNED_J2Y_VERSION" "$PINNED_YR_VERSION"
   run_check_script
   [ "$status" -eq 0 ]
-  [[ "$output" == *"pinned at 0.14.2, latest is 0.14.2"* ]]
+  [[ "$output" == *"pinned at $PINNED_J2Y_VERSION, latest is $PINNED_J2Y_VERSION"* ]]
 }
 
 # --- Abort paths ---
 
 @test "fails when json2yamlresume is behind" {
-  mock_npm "0.15.0" "0.14.2"
+  mock_npm "0.15.0" "$PINNED_YR_VERSION"
   run_check_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"ERROR: json2yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"ERROR: json2yamlresume is pinned at $PINNED_J2Y_VERSION but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
 }
 
 @test "fails when yamlresume is behind" {
-  mock_npm "0.14.2" "0.15.0"
+  mock_npm "$PINNED_J2Y_VERSION" "0.15.0"
   run_check_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"ERROR: yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"ERROR: yamlresume is pinned at $PINNED_YR_VERSION but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_YR_VERSION"* ]]
 }
 
@@ -83,13 +85,13 @@ run_check_script() {
 # --- Offline fallback ---
 
 @test "succeeds when json2yamlresume npm query fails" {
-  mock_npm "fail" "0.14.2"
+  mock_npm "fail" "$PINNED_YR_VERSION"
   run_check_script
   [ "$status" -eq 0 ]
 }
 
 @test "succeeds when yamlresume npm query fails" {
-  mock_npm "0.14.2" "fail"
+  mock_npm "$PINNED_J2Y_VERSION" "fail"
   run_check_script
   [ "$status" -eq 0 ]
 }

--- a/tests/sync-resume.bats
+++ b/tests/sync-resume.bats
@@ -7,6 +7,8 @@ setup() {
   SYNC_SCRIPT="$REPO_ROOT/scripts/sync-resume.sh"
   MOCK_DIR="$BATS_TEST_TMPDIR/mocks"
   mkdir -p "$MOCK_DIR"
+  # Pinned versions come from the same file the script under test sources.
+  source "$REPO_ROOT/resume-tools.versions"
 }
 
 # --- Helpers ---
@@ -43,7 +45,7 @@ EOF
 
 # Full mocks: both npm and docker stubbed.
 mock_all() {
-  mock_npm "${1:-0.14.2}" "${2:-0.14.2}"
+  mock_npm "${1:-$PINNED_J2Y_VERSION}" "${2:-$PINNED_YR_VERSION}"
   mock_docker
 }
 
@@ -54,7 +56,7 @@ run_script() {
 # --- Version check: happy path ---
 
 @test "version check passes when both packages match pinned versions" {
-  mock_all "0.14.2" "0.14.2"
+  mock_all
   run_script
   [ "$status" -eq 0 ]
 }
@@ -62,19 +64,19 @@ run_script() {
 # --- Version check: abort paths ---
 
 @test "version check aborts when json2yamlresume is behind latest" {
-  mock_npm "0.15.0" "0.14.2"
+  mock_npm "0.15.0" "$PINNED_YR_VERSION"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"json2yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at $PINNED_J2Y_VERSION but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_J2Y_VERSION"* ]]
   [[ "$output" != *"ERROR: yamlresume is pinned at"* ]]
 }
 
 @test "version check aborts when yamlresume is behind latest" {
-  mock_npm "0.14.2" "0.15.0"
+  mock_npm "$PINNED_J2Y_VERSION" "0.15.0"
   run_script
   [ "$status" -eq 1 ]
-  [[ "$output" == *"yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"yamlresume is pinned at $PINNED_YR_VERSION but 0.15.0 is available"* ]]
   [[ "$output" == *"Update PINNED_YR_VERSION"* ]]
 }
 
@@ -83,21 +85,21 @@ run_script() {
   run_script
   [ "$status" -eq 1 ]
   # Should fail on the first check (json2yamlresume) and never reach yamlresume
-  [[ "$output" == *"json2yamlresume is pinned at 0.14.2 but 0.15.0 is available"* ]]
+  [[ "$output" == *"json2yamlresume is pinned at $PINNED_J2Y_VERSION but 0.15.0 is available"* ]]
   [[ "$output" != *"ERROR: yamlresume is pinned at"* ]]
 }
 
 # --- Version check: offline fallback ---
 
 @test "version check continues when json2yamlresume npm query fails" {
-  mock_npm "fail" "0.14.2"
+  mock_npm "fail" "$PINNED_YR_VERSION"
   mock_docker
   run_script
   [ "$status" -eq 0 ]
 }
 
 @test "version check continues when yamlresume npm query fails" {
-  mock_npm "0.14.2" "fail"
+  mock_npm "$PINNED_J2Y_VERSION" "fail"
   mock_docker
   run_script
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Moves the pinned json2yamlresume and yamlresume versions out of scripts/sync-resume.sh into a single resume-tools.versions file, mirroring the versions.mk pattern in couimet/github-actions, and bumps both pins from 0.14.2 to 0.14.3. The bump restores the CI check-generated job, which fails on PRs while pins are stale; the external file makes future bumps one-line changes with no script or test churn.

## Changes

- Pinned resume tool versions now live in one resume-tools.versions file (repo root), sourced by scripts/sync-resume.sh and scripts/check-resume-tool-versions.sh; the check script's sed parse of its sibling script is gone
- Pins bumped from 0.14.2 to 0.14.3, restoring the stale-pin check to green
- Both bats suites build version fixtures from resume-tools.versions, so future bumps touch only that file

## Test Plan

- [ ] All 169 existing tests pass (58 Python unittests, 111 BATS tests)
- [ ] ./scripts/check-resume-tool-versions.sh exits 0 against the live npm registry (both tools pinned at 0.14.3, latest is 0.14.3)
- [ ] Manual: SKIP_VERSION_CHECK=true make sync-resume with Docker; generated resume.yml and resume-full.html are unchanged

## Related

- Closes https://github.com/couimet/couimet.github.io/issues/182

Generated by /finish-issue v2026.07.31@f2725bf • [my-claude-skills](https://github.com/couimet/my-claude-skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized pinned resume-tool versions in a single configuration file.
  * Updated synchronization and validation workflows to use the centralized versions.
* **Tests**
  * Updated automated checks to reference the centralized tool versions while preserving coverage for mismatches, outdated packages, and offline scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->